### PR TITLE
Add more fake functions for templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,6 +625,7 @@ dependencies = [
 name = "couchbase-shell"
 version = "0.0.2"
 dependencies = [
+ "chrono",
  "couchbase",
  "dirs 2.0.2",
  "fake",
@@ -1074,6 +1075,7 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a9b6b8a18de362ebd309e840fa4504a524a06f565f585962d836cecd4c08026"
 dependencies = [
+ "chrono",
  "rand 0.7.3",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,9 @@ serde = "1.0"
 serde_json = "1.0"
 
 tera = "1.1"
-fake = "2.2"
+fake = { version = "2.2", features = ["chrono"] }
 uuid = { version = "0.8", features = ["v4"] }
+chrono = { version = "0.4.11", features = ["serde"] }
 
 couchbase = { git = "https://github.com/couchbaselabs/couchbase-rs", features = ["libcouchbase-static"] }
 

--- a/src/cli/fake_data/mod.rs
+++ b/src/cli/fake_data/mod.rs
@@ -1,7 +1,16 @@
 use super::util::convert_json_value_to_nu_value;
 use crate::state::State;
+use fake::faker::address::raw::*;
+use fake::faker::boolean::raw::*;
+use fake::faker::chrono::raw::*;
+use fake::faker::company::raw::*;
+use fake::faker::currency::raw::*;
+use fake::faker::filesystem::raw::*;
 use fake::faker::internet::raw::*;
+use fake::faker::lorem::raw::*;
 use fake::faker::name::raw::*;
+use fake::faker::number::raw::*;
+use fake::faker::phone_number::raw::*;
 use fake::locales::*;
 use fake::Fake;
 use futures::executor::block_on;
@@ -186,6 +195,199 @@ fn register_functions(tera: &mut Tera) {
     tera.register_function("userName", |_: &HashMap<String, Value>| {
         Ok(Value::from(Username(EN).fake::<String>()))
     });
+
+    // Group "number"
+    tera.register_function("digit", |_: &HashMap<String, Value>| {
+        Ok(Value::from(Digit(EN).fake::<String>()))
+    });
+    tera.register_function("numberWithFormat", |args: &HashMap<String, Value>| {
+        let format = match args.get("format") {
+            Some(val) => match from_value::<String>(val.clone()) {
+                Ok(v) => v,
+                Err(_) => {
+                    return Err(tera::Error::msg(format!(
+                        "Function `numberWithFormat` received format={} but `format` can only be a string",
+                        val
+                    )));
+                }
+            },
+            None => String::from("#"),
+        };
+        // We need to convert String to &'static str here so we need to use a leak.
+        // This is a known leak which should only be called once and is small.
+        let format_str = Box::leak(format.into_boxed_str());
+        Ok(Value::from(NumberWithFormat(EN, format_str).fake::<String>()))
+    });
+
+    // Group "boolean"
+    tera.register_function("bool", |args: &HashMap<String, Value>| {
+        let ratio = match args.get("ratio") {
+            Some(val) => match from_value::<u8>(val.clone()) {
+                Ok(v) => v,
+                Err(_) => {
+                    return Err(tera::Error::msg(format!(
+                        "Function `ratio` received ratio={} but `ratio` can only be a u8",
+                        val
+                    )));
+                }
+            },
+            None => 50,
+        };
+        Ok(Value::from(Boolean(EN, ratio).fake::<bool>()))
+    });
+
+    // Group "company"
+    tera.register_function("companySuffix", |_: &HashMap<String, Value>| {
+        Ok(Value::from(CompanySuffix(EN).fake::<String>()))
+    });
+    tera.register_function("companyName", |_: &HashMap<String, Value>| {
+        Ok(Value::from(CompanyName(EN).fake::<String>()))
+    });
+    tera.register_function("buzzword", |_: &HashMap<String, Value>| {
+        Ok(Value::from(Buzzword(EN).fake::<String>()))
+    });
+    tera.register_function("catchphrase", |_: &HashMap<String, Value>| {
+        Ok(Value::from(CatchPhase(EN).fake::<String>()))
+    });
+    tera.register_function("bs", |_: &HashMap<String, Value>| {
+        Ok(Value::from(Bs(EN).fake::<String>()))
+    });
+    tera.register_function("profession", |_: &HashMap<String, Value>| {
+        Ok(Value::from(Profession(EN).fake::<String>()))
+    });
+    tera.register_function("industry", |_: &HashMap<String, Value>| {
+        Ok(Value::from(Industry(EN).fake::<String>()))
+    });
+
+    // Group "address"
+    tera.register_function("cityPrefix", |_: &HashMap<String, Value>| {
+        Ok(Value::from(CityPrefix(EN).fake::<String>()))
+    });
+    tera.register_function("citySuffix", |_: &HashMap<String, Value>| {
+        Ok(Value::from(CitySuffix(EN).fake::<String>()))
+    });
+    tera.register_function("cityName", |_: &HashMap<String, Value>| {
+        Ok(Value::from(CityName(EN).fake::<String>()))
+    });
+    tera.register_function("countryName", |_: &HashMap<String, Value>| {
+        Ok(Value::from(CountryName(EN).fake::<String>()))
+    });
+    tera.register_function("countryCode", |_: &HashMap<String, Value>| {
+        Ok(Value::from(CountryCode(EN).fake::<String>()))
+    });
+    tera.register_function("streetSuffix", |_: &HashMap<String, Value>| {
+        Ok(Value::from(StreetSuffix(EN).fake::<String>()))
+    });
+    tera.register_function("streetName", |_: &HashMap<String, Value>| {
+        Ok(Value::from(StreetName(EN).fake::<String>()))
+    });
+    tera.register_function("timeZone", |_: &HashMap<String, Value>| {
+        Ok(Value::from(TimeZone(EN).fake::<String>()))
+    });
+    tera.register_function("stateName", |_: &HashMap<String, Value>| {
+        Ok(Value::from(StateName(EN).fake::<String>()))
+    });
+    tera.register_function("stateAbbr", |_: &HashMap<String, Value>| {
+        Ok(Value::from(StateAbbr(EN).fake::<String>()))
+    });
+    tera.register_function("zipCode", |_: &HashMap<String, Value>| {
+        Ok(Value::from(ZipCode(EN).fake::<String>()))
+    });
+    tera.register_function("postCode", |_: &HashMap<String, Value>| {
+        Ok(Value::from(PostCode(EN).fake::<String>()))
+    });
+    tera.register_function("buildingNumber", |_: &HashMap<String, Value>| {
+        Ok(Value::from(BuildingNumber(EN).fake::<String>()))
+    });
+    tera.register_function("latitude", |_: &HashMap<String, Value>| {
+        Ok(Value::from(Latitude(EN).fake::<String>()))
+    });
+    tera.register_function("longitude", |_: &HashMap<String, Value>| {
+        Ok(Value::from(Longitude(EN).fake::<String>()))
+    });
+
+    // Group "phone_number"
+    tera.register_function("phoneNumber", |_: &HashMap<String, Value>| {
+        Ok(Value::from(PhoneNumber(EN).fake::<String>()))
+    });
+    tera.register_function("cellNumber", |_: &HashMap<String, Value>| {
+        Ok(Value::from(CellNumber(EN).fake::<String>()))
+    });
+
+    // Group "datetime"
+    tera.register_function("time", |_: &HashMap<String, Value>| {
+        Ok(Value::from(Time(EN).fake::<String>()))
+    });
+    tera.register_function("date", |_: &HashMap<String, Value>| {
+        Ok(Value::from(Date(EN).fake::<String>()))
+    });
+    tera.register_function("dateTime", |_: &HashMap<String, Value>| {
+        Ok(Value::from(DateTime(EN).fake::<String>()))
+    });
+    tera.register_function("duration", |_: &HashMap<String, Value>| {
+        Ok(Value::from(
+            Duration(EN).fake::<chrono::Duration>().num_milliseconds(),
+        ))
+    });
+
+    // Group "filesystem"
+    tera.register_function("filePath", |_: &HashMap<String, Value>| {
+        Ok(Value::from(FilePath(EN).fake::<String>()))
+    });
+    tera.register_function("fileName", |_: &HashMap<String, Value>| {
+        Ok(Value::from(FileName(EN).fake::<String>()))
+    });
+    tera.register_function("fileExtension", |_: &HashMap<String, Value>| {
+        Ok(Value::from(FileExtension(EN).fake::<String>()))
+    });
+    tera.register_function("dirPath", |_: &HashMap<String, Value>| {
+        Ok(Value::from(DirPath(EN).fake::<String>()))
+    });
+
+    // Group "currency"
+    tera.register_function("currencyCode", |_: &HashMap<String, Value>| {
+        Ok(Value::from(CurrencyCode(EN).fake::<String>()))
+    });
+    tera.register_function("currencyName", |_: &HashMap<String, Value>| {
+        Ok(Value::from(CurrencyName(EN).fake::<String>()))
+    });
+    tera.register_function("currencySymbol", |_: &HashMap<String, Value>| {
+        Ok(Value::from(CurrencySymbol(EN).fake::<String>()))
+    });
+
+    // Group "lorem"
+    tera.register_function("words", |args: &HashMap<String, Value>| {
+        let num = match args.get("num") {
+            Some(val) => match from_value::<usize>(val.clone()) {
+                Ok(v) => v,
+                Err(_) => {
+                    return Err(tera::Error::msg(format!(
+                        "Function `words` received num={} but `num` can only be a number",
+                        val
+                    )));
+                }
+            },
+            None => 1,
+        };
+        let words = Words(EN, num..num + 1).fake::<Vec<String>>();
+        Ok(Value::from(words.join(" ")))
+    });
+    tera.register_function("sentences", |args: &HashMap<String, Value>| {
+        let num = match args.get("num") {
+            Some(val) => match from_value::<usize>(val.clone()) {
+                Ok(v) => v,
+                Err(_) => {
+                    return Err(tera::Error::msg(format!(
+                        "Function `sentences` received num={} but `num` can only be a number",
+                        val
+                    )));
+                }
+            },
+            None => 1,
+        };
+        let sentences = Sentences(EN, num..num + 1).fake::<Vec<String>>();
+        Ok(Value::from(sentences.join(" ")))
+    });
 }
 
 static LIST_FUNCTIONS: &str = r#"[
@@ -194,7 +396,7 @@ static LIST_FUNCTIONS: &str = r#"[
     { "group": "name", "name": "lastName()", "description": "Last name", "example": "{{ lastName() }}" },
     { "group": "name", "name": "name()", "description": "firstName and lastName combined", "example": "{{ name() }}" },
     { "group": "name", "name": "title()", "description": "Person title", "example": "{{ title() }}" },
-    { "group": "name", "name": "nameWithTitle()", "description": "name and title combined", "example": "{{ nameWithTitle() }}" },    
+    { "group": "name", "name": "nameWithTitle()", "description": "name and title combined", "example": "{{ nameWithTitle() }}" },
     { "group": "name", "name": "suffix()", "description": "Person info/degree", "example": "{{ suffix() }}" },
     { "group": "internet", "name": "color()", "description": "Color hex code", "example": "{{ color() }}" },
     { "group": "internet", "name": "domainSuffix()", "description": "Domain suffix", "example": "{{ domainSuffix() }}" },
@@ -205,5 +407,45 @@ static LIST_FUNCTIONS: &str = r#"[
     { "group": "internet", "name": "userAgent()", "description": "User Agent", "example": "{{ userAgent() }}" },
     { "group": "internet", "name": "safeEmail()", "description": "Email that does not exist", "example": "{{ safeEmail() }}" },
     { "group": "internet", "name": "userName()", "description": "Username", "example": "{{ userName() }}" },
-    { "group": "internet", "name": "password(length=10)", "description": "Password", "example": "{{ password() }}" }
+    { "group": "internet", "name": "password(length=10)", "description": "Password", "example": "{{ password() }}" },
+    { "group": "number", "name": "digit()", "description": "Digit", "example": "{{ digit() }}" },
+    { "group": "number", "name": "numberWithFormat(format='#')", "description": "Number with format (escape with '')", "example": "{{ numberWithFormat(format='^###') }}" },
+    { "group": "boolean", "name": "bool(ratio=50)", "description": "Boolean", "example": "{{ bool() }}" },
+    { "group": "company", "name": "companyName()", "description": "Company name", "example": "{{ companyName() }}" },
+    { "group": "company", "name": "companySuffix()", "description": "Company suffix", "example": "{{ companySuffix() }}" },
+    { "group": "company", "name": "buzzword()", "description": "Business related buzzword", "example": "{{ buzzword() }}" },
+    { "group": "company", "name": "catchphrase()", "description": "Business related catchphrase", "example": "{{ catchphrase() }}" },
+    { "group": "company", "name": "bs()", "description": "Business related bs", "example": "{{ bs() }}" },
+    { "group": "company", "name": "profession()", "description": "Profession", "example": "{{ profession() }}" },
+    { "group": "company", "name": "industry()", "description": "Industry", "example": "{{ industry() }}" },
+    { "group": "address", "name": "cityPrefix()", "description": "City prefix", "example": "{{ cityPrefix() }}" },
+    { "group": "address", "name": "citySuffix()", "description": "City suffix", "example": "{{ citySuffix() }}" },
+    { "group": "address", "name": "cityName()", "description": "City name", "example": "{{ cityName() }}" },
+    { "group": "address", "name": "countryName()", "description": "Country name", "example": "{{ countryName() }}" },
+    { "group": "address", "name": "countryCode()", "description": "Country code", "example": "{{ countryCode() }}" },
+    { "group": "address", "name": "streetSuffix()", "description": "Street suffix", "example": "{{ streetSuffix() }}" },
+    { "group": "address", "name": "streetName()", "description": "Street name", "example": "{{ streetName() }}" },
+    { "group": "address", "name": "timeZone()", "description": "Timezone", "example": "{{ timeZone() }}" },
+    { "group": "address", "name": "stateName()", "description": "State name", "example": "{{ stateName() }}" },
+    { "group": "address", "name": "stateAbbr()", "description": "State abbreviation", "example": "{{ stateAbbr() }}" },
+    { "group": "address", "name": "zipCode()", "description": "Zip code", "example": "{{ zipCode() }}" },
+    { "group": "address", "name": "postCode()", "description": "Post code", "example": "{{ postCode() }}" },
+    { "group": "address", "name": "buildingNumber()", "description": "Building number", "example": "{{ buildingNumber() }}" },
+    { "group": "address", "name": "latitude()", "description": "Latitude", "example": "{{ latitude() }}" },
+    { "group": "address", "name": "longitude()", "description": "Longitude", "example": "{{ longitude() }}" },
+    { "group": "phone_number", "name": "phoneNumber()", "description": "Phone number", "example": "{{ phoneNumber() }}" },
+    { "group": "phone_number", "name": "cellNumber()", "description": "Cell number", "example": "{{ cellNumber() }}" },
+    { "group": "datetime", "name": "time()", "description": "Time", "example": "{{ time() }}" },
+    { "group": "datetime", "name": "date()", "description": "Date", "example": "{{ date() }}" },
+    { "group": "datetime", "name": "dateTime()", "description": "DateTime", "example": "{{ dateTime() }}" },
+    { "group": "datetime", "name": "duration()", "description": "Duration (ms)", "example": "{{ duration() }}" },
+    { "group": "filesystem", "name": "filePath()", "description": "File path", "example": "{{ filePath() }}" },
+    { "group": "filesystem", "name": "fileName())", "description": "File name", "example": "{{ fileName() }}" },
+    { "group": "filesystem", "name": "fileExtension())", "description": "File extension", "example": "{{ fileExtension() }}" },
+    { "group": "filesystem", "name": "dirPath())", "description": "Dir path", "example": "{{ dirPath() }}" },
+    { "group": "currency", "name": "currencyCode())", "description": "Currency code", "example": "{{ currencyCode() }}" },
+    { "group": "currency", "name": "currencyName())", "description": "Currency name", "example": "{{ currencyName() }}" },
+    { "group": "currency", "name": "currencySymbol())", "description": "Currency symbol", "example": "{{ currencySymbol() }}" },
+    { "group": "lorem", "name": "words(num=1))", "description": "Words", "example": "{{ words() }}" },
+    { "group": "lorem", "name": "sentences(num=1))", "description": "Sentences", "example": "{{ sentences() }}" }
 ]"#;


### PR DESCRIPTION
Added the ones that made sense to me to add. Notable exceptions are:

NumberWithFormat - I couldn't work out how to get from String to `&'static str`.
DateTimeBefore/After/Between - I couldn't figure out a day way to a) provide that in a nice way in a template and b)  use it in a template.
Paragraphs - Unsure what this is doing but it causes templates to freak out with:

```thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error("control character (\\u0000-\\u001F) found while parsing a string", line: 10, column: 0)', src/cli/fake_data/mod.rs:118:27```