### PR TITLE
avoid cookie JS popup when in an iframe

### DIFF
--- a/docs/lib/cb-docinfoprocessor.rb
+++ b/docs/lib/cb-docinfoprocessor.rb
@@ -10,8 +10,14 @@ Asciidoctor::Extensions.register do
         j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-MVPNN2');</script>
-      <script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"
-        type="text/javascript" charset="UTF-8" data-domain-script="748511ff-10bf-44bf-88b8-36382e5b5fd9"></script>
+      <script>
+        if (window.self === window.top) {
+          var s = document.createElement("script");
+          s.src = "https://cdn.cookielaw.org/scripttemplates/otSDKStub.js";
+          s.setAttribute("data-domain-script", "748511ff-10bf-44bf-88b8-36382e5b5fd9");
+          document.body.appendChild(s);
+        }
+      </script>
       <script type="text/javascript">
         function OptanonWrapper() { }
       </script>)


### PR DESCRIPTION
As part of integrating a couchbase-shell session into an web page in the Couchbase Playground, I figured having its docs conveniently right on the same page would be nice, which I attempted via an old-school iframe.

It works.

Except one annoyance... the popup to accept cookies appears every single time in the iframe.  See screenshot.  
<img width="1357" alt="Screen Shot 2021-01-30 at 9 06 36 AM" src="https://user-images.githubusercontent.com/30640/106363154-ac1eed80-62db-11eb-90fe-ed8924d463b8.png">

So, this fix is to avoid the "accept cookies" popup when the couchbase-shell docs is in an iframe.  The outermost web pages already should have made the user go through the Accept Cookies dance steps.

NOTE - I couldn't figure out how to locally test this.

But, I'm thinking the downside risk of this change is that it will disable the cookie popup (perhaps with rejoicing?) ...and in which case this change ought to be easy to revert.