### PR TITLE
Update nushell documentation link

### DIFF
--- a/docs/intro.adoc
+++ b/docs/intro.adoc
@@ -2,7 +2,7 @@
 
 Couchbase Shell is fully featured, so it does not only contain commands related to couchbase but is actually built on top of a general purpose shell called https://www.nushell.sh/[nushell]. This allows you to interact with the file system or any other command available on your machine, making it a great tool for both operational and development tasks on top of Couchbase.
 
-The following introduction only touches on the basic concepts to make you productive quickly. We recommend also checking out the great https://www.nushell.sh/documentation.html[nushell documentation] so you can get the most out of it.
+The following introduction only touches on the basic concepts to make you productive quickly. We recommend also checking out the great https://www.nushell.sh/book[nushell documentation] so you can get the most out of it.
 
 === Navigating the Shell
 


### PR DESCRIPTION
@ingenthr - Hello Matt - Updated the nushell documentation link in docs/intro.adoc
from 
https://www.nushell.sh/documentation.html

to 
https://www.nushell.sh/book

Please review. 