### PR TITLE
Fast fail commands that don't support hosted capella

### DIFF
--- a/src/cli/cloud_json.rs
+++ b/src/cli/cloud_json.rs
@@ -2,59 +2,13 @@ use crate::cli::nodes::NodeService;
 use serde_derive::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize)]
-pub(crate) struct JSONCloudClusterSummary {
-    id: String,
-    name: String,
-    #[serde(rename = "tenantId")]
-    tenant_id: String,
-    #[serde(rename = "cloudId")]
-    cloud_id: String,
-    #[serde(rename = "projectId")]
-    project_id: String,
-    services: Vec<String>,
-    nodes: i64,
-}
-
-impl JSONCloudClusterSummary {
-    pub fn id(&self) -> String {
-        self.id.clone()
-    }
-    pub fn name(&self) -> String {
-        self.name.clone()
-    }
-    // pub fn tenant_id(&self) -> String {
-    //     self.tenant_id.clone()
-    // }
-    // pub fn cloud_id(&self) -> String {
-    //     self.cloud_id.clone()
-    // }
-    // pub fn project_id(&self) -> String {
-    //     self.project_id.clone()
-    // }
-    pub fn services(&self) -> &Vec<String> {
-        &self.services
-    }
-    pub fn nodes(&self) -> i64 {
-        self.nodes
-    }
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct JSONCloudClustersSummaries {
-    data: Vec<JSONCloudClusterSummary>,
-}
-
-impl JSONCloudClustersSummaries {
-    pub fn items(&self) -> &Vec<JSONCloudClusterSummary> {
-        self.data.as_ref()
-    }
-}
-#[derive(Debug, Deserialize)]
 pub(crate) struct JSONCloudClusterSummaryV3 {
     id: String,
     name: String,
     #[serde(rename = "projectId")]
     project_id: String,
+    #[serde(rename = "cloudId", default)]
+    cloud_id: String,
     environment: String,
 }
 
@@ -65,19 +19,22 @@ impl JSONCloudClusterSummaryV3 {
     pub fn name(&self) -> String {
         self.name.clone()
     }
-    // pub fn tenant_id(&self) -> String {
-    //     self.tenant_id.clone()
-    // }
-    // pub fn cloud_id(&self) -> String {
-    //     self.cloud_id.clone()
-    // }
-    // pub fn project_id(&self) -> String {
-    //     self.project_id.clone()
-    // }
+    pub fn cloud_id(&self) -> String {
+        self.cloud_id.clone()
+    }
+    pub fn project_id(&self) -> String {
+        self.project_id.clone()
+    }
+    pub fn environment(&self) -> String {
+        self.project_id.clone()
+    }
 }
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct JSONCloudClustersSummariesItemsV3 {
+    #[serde(rename = "tenantId", default)]
+    tenant_id: String,
+    #[serde(default)]
     items: Vec<JSONCloudClusterSummaryV3>,
 }
 
@@ -89,6 +46,10 @@ pub(crate) struct JSONCloudClustersSummariesV3 {
 impl JSONCloudClustersSummariesV3 {
     pub fn items(&self) -> &Vec<JSONCloudClusterSummaryV3> {
         self.data.items.as_ref()
+    }
+
+    pub fn tenant_id(&self) -> String {
+        self.data.tenant_id.clone()
     }
 }
 

--- a/src/cli/clusters_create.rs
+++ b/src/cli/clusters_create.rs
@@ -1,7 +1,7 @@
 use crate::cli::cloud_json::{JSONCloudCreateClusterRequest, JSONCloudCreateClusterRequestV3};
 use crate::cli::util::{find_cloud_id, find_project_id};
 use crate::client::CapellaRequest;
-use crate::state::{CapellaEnvironment, State};
+use crate::state::State;
 use async_trait::async_trait;
 use log::debug;
 use nu_engine::CommandArgs;
@@ -41,6 +41,12 @@ impl nu_engine::WholeStreamCommand for ClustersCreate {
                 "the Capella organization to use",
                 None,
             )
+            .named(
+                "environment",
+                SyntaxShape::String,
+                "the Capella environment to use (\"hosted\" or \"vpc\")",
+                None,
+            )
     }
 
     fn usage(&self) -> &str {
@@ -59,6 +65,7 @@ fn clusters_create(
     let ctrl_c = args.ctrl_c();
     let definition: String = args.req(0)?;
     let capella = args.get_flag("capella")?;
+    let environment = args.get_flag("capella")?.unwrap_or("hosted".to_string());
 
     debug!("Running clusters create for {}", &definition);
 
@@ -77,7 +84,7 @@ fn clusters_create(
     };
     let project_id = find_project_id(ctrl_c.clone(), project_name, &client, deadline)?;
 
-    if control.environment() == CapellaEnvironment::Hosted {
+    if environment == "hosted".to_string() {
         let mut json: JSONCloudCreateClusterRequestV3 =
             serde_json::from_str(definition.as_str())
                 .map_err(|e| ShellError::unexpected(e.to_string()))?;

--- a/src/cli/clusters_register.rs
+++ b/src/cli/clusters_register.rs
@@ -183,7 +183,6 @@ pub fn update_config_file(guard: &mut MutexGuard<State>) -> Result<(), ShellErro
             Some(c.timeout()),
             c.active_project(),
             c.active_cloud(),
-            Some(c.environment()),
         ))
     }
 

--- a/src/cli/nodes.rs
+++ b/src/cli/nodes.rs
@@ -66,10 +66,12 @@ fn nodes(state: Arc<Mutex<State>>, args: CommandArgs) -> Result<OutputStream, Sh
         if let Some(plane) = active_cluster.capella_org() {
             let cloud = guard.capella_org_for_cluster(plane)?.client();
             let deadline = Instant::now().add(active_cluster.timeouts().management_timeout());
-            let cluster_id =
-                cloud.find_cluster_id(identifier.clone(), deadline.clone(), ctrl_c.clone())?;
+            let cluster =
+                cloud.find_cluster(identifier.clone(), deadline.clone(), ctrl_c.clone())?;
             let response = cloud.capella_request(
-                CapellaRequest::GetClusterHealth { cluster_id },
+                CapellaRequest::GetClusterHealth {
+                    cluster_id: cluster.id(),
+                },
                 deadline,
                 ctrl_c.clone(),
             )?;

--- a/src/cli/users.rs
+++ b/src/cli/users.rs
@@ -2,7 +2,7 @@ use crate::cli::cloud_json::JSONCloudUser;
 use crate::cli::user_builder::UserAndMetadata;
 use crate::cli::util::cluster_identifiers_from;
 use crate::client::{CapellaRequest, ManagementRequest};
-use crate::state::State;
+use crate::state::{CapellaEnvironment, State};
 use async_trait::async_trait;
 use log::debug;
 use nu_engine::CommandArgs;
@@ -66,10 +66,19 @@ fn users_get_all(state: Arc<Mutex<State>>, args: CommandArgs) -> Result<OutputSt
         let mut stream: Vec<Value> = if let Some(plane) = active_cluster.capella_org() {
             let cloud = guard.capella_org_for_cluster(plane)?.client();
             let deadline = Instant::now().add(active_cluster.timeouts().management_timeout());
-            let cluster_id =
-                cloud.find_cluster_id(identifier.clone(), deadline.clone(), ctrl_c.clone())?;
+            let cluster =
+                cloud.find_cluster(identifier.clone(), deadline.clone(), ctrl_c.clone())?;
+
+            if cluster.environment() == CapellaEnvironment::Hosted {
+                return Err(ShellError::unexpected(
+                    "users cannot be run against hosted Capella clusters",
+                ));
+            }
+
             let response = cloud.capella_request(
-                CapellaRequest::GetUsers { cluster_id },
+                CapellaRequest::GetUsers {
+                    cluster_id: cluster.id(),
+                },
                 deadline,
                 ctrl_c.clone(),
             )?;

--- a/src/cli/users_drop.rs
+++ b/src/cli/users_drop.rs
@@ -1,6 +1,6 @@
 use crate::cli::util::cluster_identifiers_from;
 use crate::client::{CapellaRequest, ManagementRequest};
-use crate::state::State;
+use crate::state::{CapellaEnvironment, State};
 use async_trait::async_trait;
 use log::debug;
 use nu_engine::CommandArgs;
@@ -66,11 +66,18 @@ fn users_drop(state: Arc<Mutex<State>>, args: CommandArgs) -> Result<OutputStrea
         let response = if let Some(plane) = active_cluster.capella_org() {
             let cloud = guard.capella_org_for_cluster(plane)?.client();
             let deadline = Instant::now().add(active_cluster.timeouts().management_timeout());
-            let cluster_id =
-                cloud.find_cluster_id(identifier.clone(), deadline.clone(), ctrl_c.clone())?;
+            let cluster =
+                cloud.find_cluster(identifier.clone(), deadline.clone(), ctrl_c.clone())?;
+
+            if cluster.environment() == CapellaEnvironment::Hosted {
+                return Err(ShellError::unexpected(
+                    "users drop cannot be run against hosted Capella clusters",
+                ));
+            }
+
             cloud.capella_request(
                 CapellaRequest::DeleteUser {
-                    cluster_id,
+                    cluster_id: cluster.id(),
                     username: username.clone(),
                 },
                 deadline,

--- a/src/cli/users_get.rs
+++ b/src/cli/users_get.rs
@@ -2,7 +2,7 @@ use crate::cli::cloud_json::JSONCloudUser;
 use crate::cli::user_builder::UserAndMetadata;
 use crate::cli::util::cluster_identifiers_from;
 use crate::client::{CapellaRequest, ManagementRequest};
-use crate::state::State;
+use crate::state::{CapellaEnvironment, State};
 use async_trait::async_trait;
 use log::debug;
 use nu_engine::CommandArgs;
@@ -71,10 +71,19 @@ fn users_get(state: Arc<Mutex<State>>, args: CommandArgs) -> Result<OutputStream
         let mut stream: Vec<Value> = if let Some(plane) = active_cluster.capella_org() {
             let cloud = guard.capella_org_for_cluster(plane)?.client();
             let deadline = Instant::now().add(active_cluster.timeouts().management_timeout());
-            let cluster_id =
-                cloud.find_cluster_id(identifier.clone(), deadline.clone(), ctrl_c.clone())?;
+            let cluster =
+                cloud.find_cluster(identifier.clone(), deadline.clone(), ctrl_c.clone())?;
+
+            if cluster.environment() == CapellaEnvironment::Hosted {
+                return Err(ShellError::unexpected(
+                    "users get cannot be run against hosted Capella clusters",
+                ));
+            }
+
             let response = cloud.capella_request(
-                CapellaRequest::GetUsers { cluster_id },
+                CapellaRequest::GetUsers {
+                    cluster_id: cluster.id(),
+                },
                 deadline,
                 ctrl_c.clone(),
             )?;

--- a/src/cli/users_roles.rs
+++ b/src/cli/users_roles.rs
@@ -72,7 +72,7 @@ fn run_async(state: Arc<Mutex<State>>, args: CommandArgs) -> Result<OutputStream
         };
         validate_is_not_cloud(
             active_cluster,
-            "user roles cannot be run against cloud clusters",
+            "user roles cannot be run against capella clusters",
         )?;
 
         let response = active_cluster.cluster().http_client().management_request(

--- a/src/cli/util.rs
+++ b/src/cli/util.rs
@@ -1,7 +1,4 @@
-use crate::cli::cloud_json::{
-    JSONCloudClustersSummaries, JSONCloudClustersSummariesV3, JSONCloudsProjectsResponse,
-    JSONCloudsResponse,
-};
+use crate::cli::cloud_json::{JSONCloudsProjectsResponse, JSONCloudsResponse};
 use crate::client::{CapellaClient, CapellaRequest};
 use crate::state::{RemoteCluster, State};
 use nu_engine::CommandArgs;
@@ -323,48 +320,6 @@ pub(crate) fn find_cloud_id(
     }
 
     Err(ShellError::unexpected("Cloud could not be found"))
-}
-
-pub(crate) fn find_capella_cluster_id_hosted(
-    ctrl_c: Arc<AtomicBool>,
-    name: String,
-    client: &Arc<CapellaClient>,
-    deadline: Instant,
-) -> Result<String, ShellError> {
-    let response = client.capella_request(CapellaRequest::GetClustersV3 {}, deadline, ctrl_c)?;
-    if response.status() != 200 {
-        return Err(ShellError::unexpected(response.content().to_string()));
-    };
-    let content: JSONCloudClustersSummariesV3 = serde_json::from_str(response.content())?;
-
-    for c in content.items() {
-        if c.name() == name {
-            return Ok(c.id().to_string());
-        }
-    }
-
-    Err(ShellError::unexpected("Cluster could not be found"))
-}
-
-pub(crate) fn find_capella_cluster_id_vpc(
-    ctrl_c: Arc<AtomicBool>,
-    name: String,
-    client: &Arc<CapellaClient>,
-    deadline: Instant,
-) -> Result<String, ShellError> {
-    let response = client.capella_request(CapellaRequest::GetClusters {}, deadline, ctrl_c)?;
-    if response.status() != 200 {
-        return Err(ShellError::unexpected(response.content().to_string()));
-    };
-    let content: JSONCloudClustersSummaries = serde_json::from_str(response.content())?;
-
-    for c in content.items() {
-        if c.name() == name {
-            return Ok(c.id().to_string());
-        }
-    }
-
-    Err(ShellError::unexpected("Cluster could not be found"))
 }
 
 // duration_to_golang_string creates a golang formatted string to use with timeouts. Unlike Golang

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::state::{CapellaEnvironment, RemoteCluster};
+use crate::state::RemoteCluster;
 use log::debug;
 use log::error;
 use serde::{Deserialize, Serialize};
@@ -187,7 +187,6 @@ pub struct CapellaOrganizationConfig {
     default_project: Option<String>,
     #[serde(rename(deserialize = "default-cloud", serialize = "default-cloud"))]
     default_cloud: Option<String>,
-    environment: Option<CapellaEnvironment>,
 }
 
 impl CapellaOrganizationConfig {
@@ -198,7 +197,6 @@ impl CapellaOrganizationConfig {
         management_timeout: Option<Duration>,
         default_project: Option<String>,
         default_cloud: Option<String>,
-        environment: Option<CapellaEnvironment>,
     ) -> Self {
         Self {
             identifier,
@@ -209,7 +207,6 @@ impl CapellaOrganizationConfig {
             management_timeout,
             default_project,
             default_cloud,
-            environment,
         }
     }
     pub fn identifier(&self) -> String {
@@ -229,9 +226,6 @@ impl CapellaOrganizationConfig {
     }
     pub fn default_cloud(&self) -> Option<String> {
         self.default_cloud.as_ref().cloned()
-    }
-    pub fn environment(&self) -> Option<CapellaEnvironment> {
-        self.environment.as_ref().cloned()
     }
 
     pub fn credentials_mut(&mut self) -> &mut CapellaOrganizationCredentials {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use crate::config::{
     ShellConfig, DEFAULT_ANALYTICS_TIMEOUT, DEFAULT_DATA_TIMEOUT, DEFAULT_KV_BATCH_SIZE,
     DEFAULT_MANAGEMENT_TIMEOUT, DEFAULT_QUERY_TIMEOUT, DEFAULT_SEARCH_TIMEOUT,
 };
-use crate::state::{CapellaEnvironment, RemoteCapellaOrganization, RemoteCluster};
+use crate::state::{RemoteCapellaOrganization, RemoteCluster};
 use crate::{cli::*, state::ClusterTimeouts};
 use config::ClusterTlsConfig;
 use env_logger::Env;
@@ -221,7 +221,6 @@ fn main() -> Result<(), Box<dyn Error>> {
             let name = c.identifier();
             let default_cloud = c.default_cloud();
             let default_project = c.default_project();
-            let environment = c.environment().unwrap_or(CapellaEnvironment::Hosted);
 
             let plane = RemoteCapellaOrganization::new(
                 c.secret_key(),
@@ -229,7 +228,6 @@ fn main() -> Result<(), Box<dyn Error>> {
                 management_timeout,
                 default_project,
                 default_cloud,
-                environment,
             );
 
             if active_capella_org.is_none() {

--- a/src/state.rs
+++ b/src/state.rs
@@ -13,7 +13,7 @@ use std::{collections::HashMap, time::Duration};
 pub enum CapellaEnvironment {
     #[serde(rename = "hosted")]
     Hosted,
-    #[serde(rename = "in-vpc")]
+    #[serde(rename = "vpc")]
     InVPC,
 }
 
@@ -179,7 +179,6 @@ pub struct RemoteCapellaOrganization {
     timeout: Duration,
     active_project: Mutex<Option<String>>,
     active_cloud: Mutex<Option<String>>,
-    environment: CapellaEnvironment,
 }
 
 impl RemoteCapellaOrganization {
@@ -189,7 +188,6 @@ impl RemoteCapellaOrganization {
         timeout: Duration,
         active_project: Option<String>,
         active_cloud: Option<String>,
-        environment: CapellaEnvironment,
     ) -> Self {
         Self {
             secret_key,
@@ -198,7 +196,6 @@ impl RemoteCapellaOrganization {
             timeout,
             active_project: Mutex::new(active_project),
             active_cloud: Mutex::new(active_cloud),
-            environment,
         }
     }
 
@@ -241,10 +238,6 @@ impl RemoteCapellaOrganization {
     pub fn set_active_cloud(&self, name: String) {
         let mut active = self.active_cloud.lock().unwrap();
         *active = Some(name);
-    }
-
-    pub fn environment(&self) -> CapellaEnvironment {
-        self.environment
     }
 }
 


### PR DESCRIPTION
This also removes hosted from the config and we get it from
capella when fetching the cluster id.