### PR TITLE
Allow either clusters or capella orgs to set in config

### DIFF
--- a/src/cli/buckets_config.rs
+++ b/src/cli/buckets_config.rs
@@ -50,7 +50,12 @@ fn buckets(args: CommandArgs, state: Arc<Mutex<State>>) -> Result<OutputStream, 
     let bucket_name = args.req(0)?;
 
     let guard = state.lock().unwrap();
-    let active_cluster = guard.active_cluster();
+    let active_cluster = match guard.active_cluster() {
+        Some(c) => c,
+        None => {
+            return Err(ShellError::unexpected("An active cluster must be set"));
+        }
+    };
     let cluster = active_cluster.cluster();
 
     validate_is_not_cloud(

--- a/src/cli/transactions_list_atrs.rs
+++ b/src/cli/transactions_list_atrs.rs
@@ -52,7 +52,12 @@ impl nu_engine::WholeStreamCommand for TransactionsListAtrs {
         let ctrl_c = args.ctrl_c();
 
         let guard = self.state.lock().unwrap();
-        let active_cluster = guard.active_cluster();
+        let active_cluster = match guard.active_cluster() {
+            Some(c) => c,
+            None => {
+                return Err(ShellError::unexpected("An active cluster must be set"));
+            }
+        };
         let bucket = match args
             .get_flag("bucket")?
             .or_else(|| active_cluster.active_bucket())

--- a/src/cli/use_bucket.rs
+++ b/src/cli/use_bucket.rs
@@ -37,7 +37,12 @@ impl nu_engine::WholeStreamCommand for UseBucket {
 
     fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         let guard = self.state.lock().unwrap();
-        let active = guard.active_cluster();
+        let active = match guard.active_cluster() {
+            Some(c) => c,
+            None => {
+                return Err(ShellError::unexpected("An active cluster must be set"));
+            }
+        };
 
         active.set_active_bucket(args.req(0)?);
 

--- a/src/cli/use_collection.rs
+++ b/src/cli/use_collection.rs
@@ -37,7 +37,12 @@ impl nu_engine::WholeStreamCommand for UseCollection {
 
     fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         let guard = self.state.lock().unwrap();
-        let active = guard.active_cluster();
+        let active = match guard.active_cluster() {
+            Some(c) => c,
+            None => {
+                return Err(ShellError::unexpected("An active cluster must be set"));
+            }
+        };
 
         if active.active_bucket().is_none() {
             return Err(ShellError::unexpected(

--- a/src/cli/use_scope.rs
+++ b/src/cli/use_scope.rs
@@ -37,7 +37,12 @@ impl nu_engine::WholeStreamCommand for UseScope {
 
     fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         let guard = self.state.lock().unwrap();
-        let active = guard.active_cluster();
+        let active = match guard.active_cluster() {
+            Some(c) => c,
+            None => {
+                return Err(ShellError::unexpected("An active cluster must be set"));
+            }
+        };
 
         if active.active_bucket().is_none() {
             return Err(ShellError::unexpected(

--- a/src/cli/use_timeouts.rs
+++ b/src/cli/use_timeouts.rs
@@ -64,7 +64,12 @@ impl nu_engine::WholeStreamCommand for UseTimeouts {
 
     fn run(&self, args: CommandArgs) -> Result<OutputStream, ShellError> {
         let guard = self.state.lock().unwrap();
-        let active = guard.active_cluster();
+        let active = match guard.active_cluster() {
+            Some(c) => c,
+            None => {
+                return Err(ShellError::unexpected("An active cluster must be set"));
+            }
+        };
 
         let analytics = args.get_flag("analytics-timeout")?;
         let search = args.get_flag("search-timeout")?;

--- a/src/client/cloud.rs
+++ b/src/client/cloud.rs
@@ -193,12 +193,11 @@ impl CapellaClient {
         let items = match v.get("items") {
             Some(i) => i,
             None => {
+                // No items entry means no clusters.
                 return Err(ClientError::RequestFailed {
-                    reason: Some(
-                        "Get clusters response payload unexpected format, missing items".into(),
-                    ),
+                    reason: Some("Cluster not found".into()),
                     key: None,
-                })
+                });
             }
         };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,7 @@ pub struct ShellConfig {
     version: usize,
     /// Note: clusters is kept for backwards compatibility and
     /// convenience, docs should only mention cluster
-    #[serde(alias = "cluster")]
+    #[serde(alias = "cluster", default)]
     #[serde(alias = "clusters")]
     clusters: Vec<ClusterConfig>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     };
 
     let mut active_capella_org = None;
-    let active = if config.clusters().is_empty() {
+    let active = if config.clusters().is_empty() && config.capella_orgs().is_empty() {
         let hostnames = if let Some(hosts) = opt.hostnames {
             hosts
         } else {
@@ -237,7 +237,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             capella_orgs.insert(name, plane);
         }
 
-        active.unwrap()
+        active.unwrap_or_else(|| "".into())
     };
 
     let state = Arc::new(Mutex::new(State::new(

--- a/src/state.rs
+++ b/src/state.rs
@@ -42,7 +42,9 @@ impl State {
             capella_orgs,
             active_capella_org: Mutex::new(active_capella_org),
         };
-        state.set_active(active).unwrap();
+        if !active.is_empty() {
+            state.set_active(active).unwrap();
+        }
         state
     }
 
@@ -81,18 +83,22 @@ impl State {
             *guard = active.clone();
         }
 
-        let remote = self.active_cluster();
-        let _ = remote.cluster();
+        match self.active_cluster() {
+            Some(remote) => {
+                let _ = remote.cluster();
 
-        //if remote.active_bucket().is_some() {
-        //    let _ = remote.bucket(remote.active_bucket().unwrap().as_str());
-        //}
+                //if remote.active_bucket().is_some() {
+                //    let _ = remote.bucket(remote.active_bucket().unwrap().as_str());
+                //}
 
-        if let Some(s) = remote.active_scope().clone() {
-            let _ = remote.set_active_scope(s);
-        }
-        if let Some(c) = remote.active_collection().clone() {
-            let _ = remote.set_active_collection(c);
+                if let Some(s) = remote.active_scope().clone() {
+                    let _ = remote.set_active_scope(s);
+                }
+                if let Some(c) = remote.active_collection().clone() {
+                    let _ = remote.set_active_collection(c);
+                }
+            }
+            None => {}
         }
 
         for (k, v) in &self.clusters {
@@ -104,11 +110,9 @@ impl State {
         Ok(())
     }
 
-    pub fn active_cluster(&self) -> &RemoteCluster {
+    pub fn active_cluster(&self) -> Option<&RemoteCluster> {
         let active = self.active.lock().unwrap();
-        self.clusters
-            .get(&*active)
-            .expect("No active cluster, this is a bug :(")
+        self.clusters.get(&*active)
     }
 
     pub fn tutorial(&self) -> &Tutorial {


### PR DESCRIPTION
This means that users can use cbsh against capella before they
have a cluster (allowing them to create one).