### PR TITLE
Include header size in buf len kv decode check

### DIFF
--- a/src/client/codec.rs
+++ b/src/client/codec.rs
@@ -55,7 +55,7 @@ impl Decoder for KeyValueCodec {
             Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidInput, e)),
         } as usize;
 
-        if buf_len < total_body_len {
+        if buf_len < (HEADER_SIZE + total_body_len) {
             return Ok(None);
         }
 


### PR DESCRIPTION
We need to check that the buffer size is HEADER_SIZE+total_body_len
when we validate that we have received enough bytes to successfully
decode a packet.