### PR TITLE
Improve doc command error messages

### DIFF
--- a/src/cli/analytics.rs
+++ b/src/cli/analytics.rs
@@ -1,6 +1,6 @@
 use crate::cli::error::{
-    client_error_to_shell_error, deserialize_error, malformed_response_error,
-    unexpected_status_code_error,
+    analytics_error, client_error_to_shell_error, deserialize_error, malformed_response_error,
+    unexpected_status_code_error, AnalyticsErrorReason,
 };
 use crate::cli::util::{
     cluster_identifiers_from, convert_row_to_nu_value, duration_to_golang_string,
@@ -16,7 +16,6 @@ use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
     Category, IntoPipelineData, PipelineData, ShellError, Signature, Span, SyntaxShape, Value,
 };
-use std::collections::HashMap;
 use std::ops::Add;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
@@ -93,7 +92,7 @@ fn run(
 
     let guard = state.lock().unwrap();
 
-    let scope = call.get_flag(engine_state, stack, "scope")?;
+    let scope: Option<String> = call.get_flag(engine_state, stack, "scope")?;
     let with_meta = call.has_flag("with-meta");
 
     debug!("Running analytics query {}", &statement);
@@ -106,54 +105,16 @@ fn run(
             .or_else(|| active_cluster.active_bucket());
         let maybe_scope = bucket.and_then(|b| scope.clone().map(|s| (b, s)));
 
-        let response = send_analytics_query(
+        results.extend(do_analytics_query(
+            identifier.clone(),
             active_cluster,
             maybe_scope,
-            statement.clone(),
+            &statement,
             ctrl_c.clone(),
             span,
-        )?;
-
-        if with_meta {
-            let content: serde_json::Value =
-                serde_json::from_str(response.content()).map_err(|_e| {
-                    unexpected_status_code_error(response.status(), response.content(), span)
-                })?;
-            results.push(convert_row_to_nu_value(&content, span, identifier.clone())?);
-        } else {
-            let content: HashMap<String, serde_json::Value> =
-                serde_json::from_str(response.content())
-                    .map_err(|e| deserialize_error(e.to_string(), span))?;
-            if let Some(content_errors) = content.get("errors") {
-                if let Some(arr) = content_errors.as_array() {
-                    for result in arr {
-                        results.push(convert_row_to_nu_value(result, span, identifier.clone())?);
-                    }
-                } else {
-                    return Err(malformed_response_error(
-                        "analytics rows not an array",
-                        content_errors.to_string(),
-                        span,
-                    ));
-                }
-            } else if let Some(content_results) = content.get("results") {
-                if let Some(arr) = content_results.as_array() {
-                    dbg!(&arr);
-                    for result in arr {
-                        results.push(convert_row_to_nu_value(result, span, identifier.clone())?);
-                    }
-                } else {
-                    return Err(malformed_response_error(
-                        "analytics toplevel result not  an object",
-                        content_results.to_string(),
-                        span,
-                    ));
-                }
-            } else {
-                // Queries like "create dataset" can end up here.
-                continue;
-            };
-        }
+            with_meta,
+            true,
+        )?);
     }
 
     Ok(Value::List {
@@ -165,7 +126,7 @@ fn run(
 
 pub fn send_analytics_query(
     active_cluster: &RemoteCluster,
-    scope: Option<(String, String)>,
+    scope: impl Into<Option<(String, String)>>,
     statement: impl Into<String>,
     ctrl_c: Arc<AtomicBool>,
     span: Span,
@@ -176,7 +137,7 @@ pub fn send_analytics_query(
         .analytics_query_request(
             AnalyticsQueryRequest::Execute {
                 statement: statement.into(),
-                scope,
+                scope: scope.into(),
                 timeout: duration_to_golang_string(active_cluster.timeouts().analytics_timeout()),
             },
             Instant::now().add(active_cluster.timeouts().analytics_timeout()),
@@ -184,5 +145,104 @@ pub fn send_analytics_query(
         )
         .map_err(|e| client_error_to_shell_error(e, span))?;
 
+    if response.status() != 200 {
+        return Err(unexpected_status_code_error(
+            response.status(),
+            response.content(),
+            span,
+        ));
+    }
+
     Ok(response)
+}
+
+pub fn do_analytics_query(
+    identifier: String,
+    active_cluster: &RemoteCluster,
+    scope: impl Into<Option<(String, String)>>,
+    statement: impl Into<String>,
+    ctrl_c: Arc<AtomicBool>,
+    span: Span,
+    with_meta: bool,
+    could_contain_mutations: bool,
+) -> Result<Vec<Value>, ShellError> {
+    let response = send_analytics_query(active_cluster, scope, statement, ctrl_c, span)?;
+
+    let content: serde_json::Value = serde_json::from_str(response.content())
+        .map_err(|e| deserialize_error(e.to_string(), span))?;
+
+    let mut results: Vec<Value> = vec![];
+    if with_meta {
+        let converted = convert_row_to_nu_value(&content, span, identifier)?;
+        results.push(converted);
+        return Ok(results);
+    }
+
+    if let Some(content_errors) = content.get("errors") {
+        return if let Some(arr) = content_errors.as_array() {
+            if arr.len() == 1 {
+                let e = match arr.get(0) {
+                    Some(e) => e,
+                    None => {
+                        return Err(malformed_response_error(
+                            "analytics errors present but empty",
+                            content_errors.to_string(),
+                            span,
+                        ))
+                    }
+                };
+                let code = e.get("code").map(|c| c.as_i64().unwrap_or_default());
+                let reason = match code {
+                    Some(c) => AnalyticsErrorReason::from(c),
+                    None => AnalyticsErrorReason::UnknownError,
+                };
+                let msg = match e.get("msg") {
+                    Some(msg) => msg.to_string(),
+                    None => "".to_string(),
+                };
+                Err(analytics_error(reason, code, msg, span))
+            } else {
+                let messages = arr
+                    .into_iter()
+                    .map(|e| e.to_string())
+                    .collect::<Vec<String>>()
+                    .join(",");
+
+                Err(analytics_error(
+                    AnalyticsErrorReason::MultiErrors,
+                    None,
+                    messages,
+                    span,
+                ))
+            }
+        } else {
+            Err(malformed_response_error(
+                "analytics errors not an array",
+                content_errors.to_string(),
+                span,
+            ))
+        };
+    } else if let Some(content_results) = content.get("results") {
+        if let Some(arr) = content_results.as_array() {
+            for result in arr {
+                results.push(convert_row_to_nu_value(result, span, identifier.clone())?);
+            }
+        } else {
+            return Err(malformed_response_error(
+                "analytics rows not an array",
+                content_results.to_string(),
+                span,
+            ));
+        }
+    } else {
+        if !could_contain_mutations {
+            return Err(malformed_response_error(
+                "analytics toplevel result not an object",
+                content.to_string(),
+                span,
+            ));
+        }
+    }
+
+    Ok(results)
 }

--- a/src/cli/analytics_buckets.rs
+++ b/src/cli/analytics_buckets.rs
@@ -102,7 +102,7 @@ pub fn do_non_mutation_analytics_query(
     span: Span,
     with_meta: bool,
 ) -> Result<Vec<Value>, ShellError> {
-    let response = send_analytics_query(active_cluster, None, statement, ctrl_c)?;
+    let response = send_analytics_query(active_cluster, None, statement, ctrl_c, span)?;
 
     let content: serde_json::Value = serde_json::from_str(response.content())
         .map_err(|_e| unexpected_status_code_error(response.status(), response.content(), span))?;

--- a/src/cli/analytics_datasets.rs
+++ b/src/cli/analytics_datasets.rs
@@ -1,4 +1,4 @@
-use crate::cli::analytics_buckets::do_non_mutation_analytics_query;
+use crate::cli::analytics::do_analytics_query;
 use crate::cli::util::{cluster_identifiers_from, get_active_cluster};
 use crate::state::State;
 use log::debug;
@@ -74,13 +74,15 @@ fn datasets(
     for identifier in cluster_identifiers {
         let active_cluster = get_active_cluster(identifier.clone(), &guard, span)?;
 
-        results.extend(do_non_mutation_analytics_query(
+        results.extend(do_analytics_query(
             identifier.clone(),
             active_cluster,
+            None,
             statement,
             ctrl_c.clone(),
             span,
             with_meta,
+            false,
         )?);
     }
 

--- a/src/cli/analytics_dataverses.rs
+++ b/src/cli/analytics_dataverses.rs
@@ -1,4 +1,4 @@
-use crate::cli::analytics_buckets::do_non_mutation_analytics_query;
+use crate::cli::analytics::do_analytics_query;
 use crate::cli::util::{cluster_identifiers_from, get_active_cluster};
 use crate::state::State;
 use log::debug;
@@ -73,13 +73,15 @@ fn dataverses(
     for identifier in cluster_identifiers {
         let active_cluster = get_active_cluster(identifier.clone(), &guard, span)?;
 
-        results.extend(do_non_mutation_analytics_query(
+        results.extend(do_analytics_query(
             identifier.clone(),
             active_cluster,
+            None,
             statement,
             ctrl_c.clone(),
             span,
             with_meta,
+            false,
         )?);
     }
 

--- a/src/cli/analytics_indexes.rs
+++ b/src/cli/analytics_indexes.rs
@@ -1,4 +1,4 @@
-use crate::cli::analytics_buckets::do_non_mutation_analytics_query;
+use crate::cli::analytics::do_analytics_query;
 use crate::cli::util::{cluster_identifiers_from, get_active_cluster};
 use crate::state::State;
 use log::debug;
@@ -73,13 +73,15 @@ fn indexes(
     for identifier in cluster_identifiers {
         let active_cluster = get_active_cluster(identifier.clone(), &guard, span)?;
 
-        results.extend(do_non_mutation_analytics_query(
+        results.extend(do_analytics_query(
             identifier.clone(),
             active_cluster,
+            None,
             statement,
             ctrl_c.clone(),
             span,
             with_meta,
+            false,
         )?);
     }
 

--- a/src/cli/analytics_links.rs
+++ b/src/cli/analytics_links.rs
@@ -1,4 +1,4 @@
-use crate::cli::analytics_buckets::do_non_mutation_analytics_query;
+use crate::cli::analytics::do_analytics_query;
 use crate::cli::util::{cluster_identifiers_from, get_active_cluster};
 use crate::state::State;
 use log::debug;
@@ -73,13 +73,15 @@ fn links(
     for identifier in cluster_identifiers {
         let active_cluster = get_active_cluster(identifier.clone(), &guard, span)?;
 
-        results.extend(do_non_mutation_analytics_query(
+        results.extend(do_analytics_query(
             identifier.clone(),
             active_cluster,
+            None,
             statement,
             ctrl_c.clone(),
             span,
             with_meta,
+            false,
         )?);
     }
 

--- a/src/cli/analytics_pending_mutations.rs
+++ b/src/cli/analytics_pending_mutations.rs
@@ -1,4 +1,6 @@
-use crate::cli::error::{deserialize_error, unexpected_status_code_error};
+use crate::cli::error::{
+    client_error_to_shell_error, deserialize_error, unexpected_status_code_error,
+};
 use crate::cli::util::{
     cluster_identifiers_from, convert_row_to_nu_value, get_active_cluster, validate_is_not_cloud,
 };
@@ -80,7 +82,8 @@ fn pending_mutations(
                 AnalyticsQueryRequest::PendingMutations,
                 Instant::now().add(active_cluster.timeouts().analytics_timeout()),
                 ctrl_c.clone(),
-            )?;
+            )
+            .map_err(|e| client_error_to_shell_error(e, span))?;
 
         match response.status() {
             200 => {}

--- a/src/cli/buckets_create.rs
+++ b/src/cli/buckets_create.rs
@@ -161,7 +161,7 @@ fn buckets_create(
 
         let form = settings
             .as_form(false)
-            .map_err(|e| generic_error(format!("Invalid setting {}", e), None, span))?;
+            .map_err(|e| generic_error("Invalid argument", e.to_string(), span))?;
         let payload =
             serde_urlencoded::to_string(&form).map_err(|e| serialize_error(e.to_string(), span))?;
 

--- a/src/cli/buckets_get.rs
+++ b/src/cli/buckets_get.rs
@@ -103,7 +103,14 @@ fn buckets_get(
         match response.status() {
             200 => {}
             404 => {
-                return Err(bucket_not_found_error(bucket, span));
+                if response
+                    .content()
+                    .to_string()
+                    .to_lowercase()
+                    .contains("resource not found")
+                {
+                    return Err(bucket_not_found_error(bucket, span));
+                }
             }
             _ => {
                 return Err(unexpected_status_code_error(

--- a/src/cli/buckets_update.rs
+++ b/src/cli/buckets_update.rs
@@ -1,7 +1,7 @@
 use crate::cli::buckets_builder::{BucketSettings, DurabilityLevel, JSONBucketSettings};
 use crate::cli::error::{
-    client_error_to_shell_error, deserialize_error, generic_error, serialize_error,
-    unexpected_status_code_error,
+    bucket_not_found_error, client_error_to_shell_error, deserialize_error, generic_error,
+    serialize_error, unexpected_status_code_error,
 };
 use crate::cli::util::{cluster_identifiers_from, get_active_cluster, validate_is_not_cloud};
 use crate::client::ManagementRequest;
@@ -174,6 +174,16 @@ fn buckets_update(
             200 => {}
             201 => {}
             202 => {}
+            404 => {
+                if response
+                    .content()
+                    .to_string()
+                    .to_lowercase()
+                    .contains("resource not found")
+                {
+                    return Err(bucket_not_found_error(name, span));
+                }
+            }
             _ => {
                 return Err(unexpected_status_code_error(
                     response.status(),

--- a/src/cli/buckets_update.rs
+++ b/src/cli/buckets_update.rs
@@ -139,7 +139,7 @@ fn buckets_update(
         let content: JSONBucketSettings = serde_json::from_str(get_response.content())
             .map_err(|e| deserialize_error(e.to_string(), span))?;
         let mut settings = BucketSettings::try_from(content)
-            .map_err(|e| generic_error(format!("Invalid setting {}", e), None, span))?;
+            .map_err(|e| generic_error("Invalid argument", e.to_string(), span))?;
 
         update_bucket_settings(
             &mut settings,
@@ -153,7 +153,7 @@ fn buckets_update(
 
         let form = settings
             .as_form(true)
-            .map_err(|e| generic_error(format!("Invalid setting {}", e), None, span))?;
+            .map_err(|e| generic_error("Invalid argument", e.to_string(), span))?;
         let payload =
             serde_urlencoded::to_string(&form).map_err(|e| serialize_error(e.to_string(), span))?;
 
@@ -215,7 +215,7 @@ fn update_bucket_settings(
             Err(e) => {
                 return Err(generic_error(
                     format!("Failed to parse num replicas {}", e),
-                    None,
+                    "Num replicas must be an unsigned 32 bit integer".to_string(),
                     span,
                 ));
             }

--- a/src/cli/clusters.rs
+++ b/src/cli/clusters.rs
@@ -1,5 +1,7 @@
 use crate::cli::cloud_json::JSONCloudClustersSummariesV3;
-use crate::cli::error::{deserialize_error, unexpected_status_code_error};
+use crate::cli::error::{
+    client_error_to_shell_error, deserialize_error, unexpected_status_code_error,
+};
 use crate::cli::util::NuValueMap;
 use crate::client::CapellaRequest;
 use crate::state::State;
@@ -75,11 +77,13 @@ fn clusters(
     }?;
     let client = control.client();
 
-    let response = client.capella_request(
-        CapellaRequest::GetClustersV3 {},
-        Instant::now().add(control.timeout()),
-        ctrl_c,
-    )?;
+    let response = client
+        .capella_request(
+            CapellaRequest::GetClustersV3 {},
+            Instant::now().add(control.timeout()),
+            ctrl_c,
+        )
+        .map_err(|e| client_error_to_shell_error(e, span))?;
     if response.status() != 200 {
         return Err(unexpected_status_code_error(
             response.status(),

--- a/src/cli/clusters_drop.rs
+++ b/src/cli/clusters_drop.rs
@@ -5,7 +5,7 @@ use std::ops::Add;
 use std::sync::{Arc, Mutex};
 use tokio::time::Instant;
 
-use crate::cli::error::unexpected_status_code_error;
+use crate::cli::error::{client_error_to_shell_error, unexpected_status_code_error};
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -79,14 +79,18 @@ fn clusters_drop(
     let client = control.client();
 
     let deadline = Instant::now().add(control.timeout());
-    let cluster = client.find_cluster(name, deadline, ctrl_c.clone())?;
-    let response = client.capella_request(
-        CapellaRequest::DeleteClusterV3 {
-            cluster_id: cluster.id(),
-        },
-        deadline,
-        ctrl_c,
-    )?;
+    let cluster = client
+        .find_cluster(name, deadline, ctrl_c.clone())
+        .map_err(|e| client_error_to_shell_error(e, span))?;
+    let response = client
+        .capella_request(
+            CapellaRequest::DeleteClusterV3 {
+                cluster_id: cluster.id(),
+            },
+            deadline,
+            ctrl_c,
+        )
+        .map_err(|e| client_error_to_shell_error(e, span))?;
     if response.status() != 202 {
         return Err(unexpected_status_code_error(
             response.status(),

--- a/src/cli/clusters_get.rs
+++ b/src/cli/clusters_get.rs
@@ -6,7 +6,9 @@ use std::ops::Add;
 use std::sync::{Arc, Mutex};
 use tokio::time::Instant;
 
-use crate::cli::error::{deserialize_error, unexpected_status_code_error};
+use crate::cli::error::{
+    client_error_to_shell_error, deserialize_error, unexpected_status_code_error,
+};
 use crate::cli::util::NuValueMap;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
@@ -80,14 +82,18 @@ fn clusters_get(
     let client = control.client();
 
     let deadline = Instant::now().add(control.timeout());
-    let cluster = client.find_cluster(name, deadline, ctrl_c.clone())?;
-    let response = client.capella_request(
-        CapellaRequest::GetClusterV3 {
-            cluster_id: cluster.id(),
-        },
-        deadline,
-        ctrl_c,
-    )?;
+    let cluster = client
+        .find_cluster(name, deadline, ctrl_c.clone())
+        .map_err(|e| client_error_to_shell_error(e, span))?;
+    let response = client
+        .capella_request(
+            CapellaRequest::GetClusterV3 {
+                cluster_id: cluster.id(),
+            },
+            deadline,
+            ctrl_c,
+        )
+        .map_err(|e| client_error_to_shell_error(e, span))?;
     if response.status() != 200 {
         return Err(unexpected_status_code_error(
             response.status(),

--- a/src/cli/collections_drop.rs
+++ b/src/cli/collections_drop.rs
@@ -9,7 +9,9 @@ use std::sync::{Arc, Mutex};
 use tokio::time::Instant;
 
 use crate::cli::collections::get_bucket_or_active;
-use crate::cli::error::{no_active_scope_error, unexpected_status_code_error};
+use crate::cli::error::{
+    client_error_to_shell_error, no_active_scope_error, unexpected_status_code_error,
+};
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -99,15 +101,19 @@ fn collections_drop(
             &collection, &bucket, &scope_name
         );
 
-        let response = active_cluster.cluster().http_client().management_request(
-            DropCollection {
-                scope: scope_name,
-                bucket,
-                name: collection.clone(),
-            },
-            Instant::now().add(active_cluster.timeouts().management_timeout()),
-            ctrl_c.clone(),
-        )?;
+        let response = active_cluster
+            .cluster()
+            .http_client()
+            .management_request(
+                DropCollection {
+                    scope: scope_name,
+                    bucket,
+                    name: collection.clone(),
+                },
+                Instant::now().add(active_cluster.timeouts().management_timeout()),
+                ctrl_c.clone(),
+            )
+            .map_err(|e| client_error_to_shell_error(e, span))?;
 
         match response.status() {
             200 => {}

--- a/src/cli/doc_insert.rs
+++ b/src/cli/doc_insert.rs
@@ -74,6 +74,7 @@ impl Command for DocInsert {
                 "the maximum number of items to batch send at a time",
                 None,
             )
+            .switch("halt-on-error", "halt on any errors", Some('e'))
             .category(Category::Custom("couchbase".to_string()))
     }
 

--- a/src/cli/doc_replace.rs
+++ b/src/cli/doc_replace.rs
@@ -74,6 +74,7 @@ impl Command for DocReplace {
                 "the maximum number of items to batch send at a time",
                 None,
             )
+            .switch("halt-on-error", "halt on any errors", Some('e'))
             .category(Category::Custom("couchbase".to_string()))
     }
 

--- a/src/cli/error.rs
+++ b/src/cli/error.rs
@@ -1,3 +1,4 @@
+use crate::client::ClientError;
 use nu_protocol::{ShellError, Span};
 
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone)]
@@ -207,4 +208,8 @@ pub fn generic_error(
         span: Some(span),
     }
     .into()
+}
+
+pub fn client_error_to_shell_error(error: ClientError, span: Span) -> ShellError {
+    generic_error(error.message(), error.expanded_message(), span)
 }

--- a/src/cli/projects.rs
+++ b/src/cli/projects.rs
@@ -7,7 +7,9 @@ use std::ops::Add;
 use std::sync::{Arc, Mutex};
 use tokio::time::Instant;
 
-use crate::cli::error::{deserialize_error, unexpected_status_code_error};
+use crate::cli::error::{
+    client_error_to_shell_error, deserialize_error, unexpected_status_code_error,
+};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{Category, IntoPipelineData, PipelineData, ShellError, Signature, Value};
@@ -62,11 +64,13 @@ fn projects(
     let guard = state.lock().unwrap();
     let control = guard.active_capella_org()?;
     let client = control.client();
-    let response = client.capella_request(
-        CapellaRequest::GetProjects {},
-        Instant::now().add(control.timeout()),
-        ctrl_c,
-    )?;
+    let response = client
+        .capella_request(
+            CapellaRequest::GetProjects {},
+            Instant::now().add(control.timeout()),
+            ctrl_c,
+        )
+        .map_err(|e| client_error_to_shell_error(e, span))?;
     if response.status() != 200 {
         return Err(unexpected_status_code_error(
             response.status(),

--- a/src/cli/projects_create.rs
+++ b/src/cli/projects_create.rs
@@ -6,7 +6,9 @@ use std::ops::Add;
 use std::sync::{Arc, Mutex};
 use tokio::time::Instant;
 
-use crate::cli::error::{serialize_error, unexpected_status_code_error};
+use crate::cli::error::{
+    client_error_to_shell_error, serialize_error, unexpected_status_code_error,
+};
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -66,14 +68,16 @@ fn projects_create(
     let control = guard.active_capella_org()?;
     let client = control.client();
     let project = JSONCloudCreateProjectRequest::new(name);
-    let response = client.capella_request(
-        CapellaRequest::CreateProject {
-            payload: serde_json::to_string(&project)
-                .map_err(|e| serialize_error(e.to_string(), span))?,
-        },
-        Instant::now().add(control.timeout()),
-        ctrl_c,
-    )?;
+    let response = client
+        .capella_request(
+            CapellaRequest::CreateProject {
+                payload: serde_json::to_string(&project)
+                    .map_err(|e| serialize_error(e.to_string(), span))?,
+            },
+            Instant::now().add(control.timeout()),
+            ctrl_c,
+        )
+        .map_err(|e| client_error_to_shell_error(e, span))?;
     if response.status() != 201 {
         return Err(unexpected_status_code_error(
             response.status(),

--- a/src/cli/query_advise.rs
+++ b/src/cli/query_advise.rs
@@ -85,6 +85,7 @@ fn run(
             statement.clone(),
             maybe_scope,
             ctrl_c.clone(),
+            span,
         )?;
         drop(guard);
 

--- a/src/cli/scopes_create.rs
+++ b/src/cli/scopes_create.rs
@@ -7,7 +7,9 @@ use std::sync::{Arc, Mutex};
 use tokio::time::Instant;
 
 use crate::cli::collections::get_bucket_or_active;
-use crate::cli::error::{serialize_error, unexpected_status_code_error};
+use crate::cli::error::{
+    client_error_to_shell_error, serialize_error, unexpected_status_code_error,
+};
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -90,11 +92,15 @@ fn run(
         let form = vec![("name", scope.clone())];
         let payload =
             serde_urlencoded::to_string(&form).map_err(|e| serialize_error(e.to_string(), span))?;
-        let response = active_cluster.cluster().http_client().management_request(
-            ManagementRequest::CreateScope { payload, bucket },
-            Instant::now().add(active_cluster.timeouts().management_timeout()),
-            ctrl_c.clone(),
-        )?;
+        let response = active_cluster
+            .cluster()
+            .http_client()
+            .management_request(
+                ManagementRequest::CreateScope { payload, bucket },
+                Instant::now().add(active_cluster.timeouts().management_timeout()),
+                ctrl_c.clone(),
+            )
+            .map_err(|e| client_error_to_shell_error(e, span))?;
 
         match response.status() {
             200 => {}

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -1,4 +1,4 @@
-use crate::cli::error::unexpected_status_code_error;
+use crate::cli::error::{client_error_to_shell_error, unexpected_status_code_error};
 use crate::cli::util::{
     cluster_identifiers_from, duration_to_golang_string, get_active_cluster, NuValueMap,
 };
@@ -96,7 +96,8 @@ fn run(
                 },
                 Instant::now().add(active_cluster.timeouts().search_timeout()),
                 ctrl_c.clone(),
-            )?;
+            )
+            .map_err(|e| client_error_to_shell_error(e, span))?;
 
         let rows: SearchResultData = match response.status() {
             200 => serde_json::from_str(response.content()).map_err(|_e| {

--- a/src/cli/users_get.rs
+++ b/src/cli/users_get.rs
@@ -9,7 +9,9 @@ use std::ops::Add;
 use std::sync::{Arc, Mutex};
 use tokio::time::Instant;
 
-use crate::cli::error::{deserialize_error, unexpected_status_code_error};
+use crate::cli::error::{
+    client_error_to_shell_error, deserialize_error, unexpected_status_code_error,
+};
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -81,13 +83,17 @@ fn users_get(
         let active_cluster = get_active_cluster(identifier.clone(), &guard, span)?;
         validate_is_not_cloud(active_cluster, "users get", span)?;
 
-        let response = active_cluster.cluster().http_client().management_request(
-            ManagementRequest::GetUser {
-                username: username.clone(),
-            },
-            Instant::now().add(active_cluster.timeouts().management_timeout()),
-            ctrl_c.clone(),
-        )?;
+        let response = active_cluster
+            .cluster()
+            .http_client()
+            .management_request(
+                ManagementRequest::GetUser {
+                    username: username.clone(),
+                },
+                Instant::now().add(active_cluster.timeouts().management_timeout()),
+                ctrl_c.clone(),
+            )
+            .map_err(|e| client_error_to_shell_error(e, span))?;
 
         let user_and_meta: UserAndMetadata = match response.status() {
             200 => serde_json::from_str(response.content())

--- a/src/cli/util.rs
+++ b/src/cli/util.rs
@@ -3,7 +3,8 @@ use crate::cli::error::CBShellError::{
     GenericError, MustNotBeCapella, ProjectNotFound, UnexpectedResponseStatus,
 };
 use crate::cli::error::{
-    cluster_not_found_error, deserialize_error, malformed_response_error, no_active_bucket_error,
+    client_error_to_shell_error, cluster_not_found_error, deserialize_error,
+    malformed_response_error, no_active_bucket_error,
 };
 use crate::client::{CapellaClient, CapellaRequest};
 use crate::state::{RemoteCluster, State};
@@ -266,7 +267,9 @@ pub(crate) fn find_project_id(
     deadline: Instant,
     span: Span,
 ) -> Result<String, ShellError> {
-    let response = client.capella_request(CapellaRequest::GetProjects {}, deadline, ctrl_c)?;
+    let response = client
+        .capella_request(CapellaRequest::GetProjects {}, deadline, ctrl_c)
+        .map_err(|e| client_error_to_shell_error(e, span))?;
     if response.status() != 200 {
         return Err(UnexpectedResponseStatus {
             status_code: response.status(),

--- a/src/cli/whoami.rs
+++ b/src/cli/whoami.rs
@@ -7,7 +7,9 @@ use std::ops::Add;
 use std::sync::{Arc, Mutex};
 use tokio::time::Instant;
 
-use crate::cli::error::{deserialize_error, unexpected_status_code_error};
+use crate::cli::error::{
+    client_error_to_shell_error, deserialize_error, unexpected_status_code_error,
+};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
@@ -73,11 +75,15 @@ fn whoami(
     for identifier in cluster_identifiers {
         let cluster = get_active_cluster(identifier.clone(), &guard, span)?;
 
-        let response = cluster.cluster().http_client().management_request(
-            ManagementRequest::Whoami,
-            Instant::now().add(cluster.timeouts().management_timeout()),
-            ctrl_c.clone(),
-        )?;
+        let response = cluster
+            .cluster()
+            .http_client()
+            .management_request(
+                ManagementRequest::Whoami,
+                Instant::now().add(cluster.timeouts().management_timeout()),
+                ctrl_c.clone(),
+            )
+            .map_err(|e| client_error_to_shell_error(e, span))?;
 
         match response.status() {
             200 => {}

--- a/src/client/cloud.rs
+++ b/src/client/cloud.rs
@@ -186,10 +186,7 @@ impl CapellaClient {
             Some(i) => i,
             None => {
                 // No items entry means no clusters.
-                return Err(ClientError::RequestFailed {
-                    reason: Some("Cluster not found".to_string()),
-                    key: None,
-                });
+                return Err(ClientError::CapellaClusterNotFound { name: cluster_name });
             }
         };
 
@@ -202,7 +199,7 @@ impl CapellaClient {
             }
         }
 
-        Err(ClientError::ClusterNotFound { name: cluster_name })
+        Err(ClientError::CapellaClusterNotFound { name: cluster_name })
     }
 
     pub fn capella_request(

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -1,36 +1,79 @@
-use nu_protocol::ShellError;
-use serde::{Deserialize, Serialize};
+use crate::client::protocol::{KvResponse, Status};
+use serde::Deserialize;
 use std::fmt;
+use std::fmt::Debug;
 
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Serialize, Deserialize, Hash)]
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Hash)]
+pub enum ConfigurationLoadFailedReason {
+    NotFound { bucket: Option<String> },
+    Unauthorized,
+    Forbidden,
+    Unknown { reason: String },
+}
+
+impl fmt::Display for ConfigurationLoadFailedReason {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let message = match self {
+            ConfigurationLoadFailedReason::NotFound { bucket } => match bucket {
+                Some(b) => format!(
+                    "Does the bucket {} exist and does the user have permission to access it?",
+                    b
+                ),
+                None => "Could not fetch cluster level config, the endpoint could not be found"
+                    .to_string(),
+            },
+            ConfigurationLoadFailedReason::Unauthorized => {
+                "Unauthorized, does the user exist?".to_string()
+            }
+            ConfigurationLoadFailedReason::Forbidden => {
+                "Forbidden, does the user have the correct permissions?".to_string()
+            }
+            ConfigurationLoadFailedReason::Unknown { reason } => reason.to_string(),
+        };
+
+        write!(f, "{}", message)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Hash)]
 pub enum ClientError {
     ConfigurationLoadFailed {
-        reason: Option<String>,
-    },
-    CollectionManifestLoadFailed {
-        reason: Option<String>,
+        reason: ConfigurationLoadFailedReason,
     },
     CollectionNotFound {
-        key: Option<String>,
+        name: String,
+        scope_name: String,
+    },
+    ClusterNotContactable {
+        cluster: String,
+        reason: String,
+    },
+    CollectionUnknownDuringRequest {
+        key: String,
+        cid: u32,
     },
     ScopeNotFound {
-        key: Option<String>,
+        name: String,
     },
     KeyNotFound {
-        key: Option<String>,
+        key: String,
     },
     KeyAlreadyExists {
-        key: Option<String>,
+        key: String,
     },
-    AccessError,
-    AuthError,
+    AccessError {
+        reason: Option<String>,
+    },
+    AuthError {
+        reason: Option<String>,
+    },
     Timeout {
         key: Option<String>,
     },
     Cancelled {
         key: Option<String>,
     },
-    ClusterNotFound {
+    CapellaClusterNotFound {
         name: String,
     },
     RequestFailed {
@@ -42,51 +85,123 @@ pub enum ClientError {
 impl ClientError {
     pub fn key(&self) -> Option<String> {
         match self {
-            ClientError::CollectionNotFound { key } => key.clone(),
-            ClientError::ScopeNotFound { key } => key.clone(),
-            ClientError::KeyNotFound { key } => key.clone(),
-            ClientError::KeyAlreadyExists { key } => key.clone(),
-            ClientError::Timeout { key } => key.clone(),
+            ClientError::CollectionUnknownDuringRequest { key, .. } => Some(key.clone()),
+            ClientError::KeyNotFound { key } => Some(key.clone()),
+            ClientError::KeyAlreadyExists { key } => Some(key.clone()),
+            ClientError::Timeout { key, .. } => key.clone(),
             ClientError::Cancelled { key } => key.clone(),
             ClientError::RequestFailed { key, .. } => key.clone(),
             _ => None,
+        }
+    }
+
+    pub fn message(&self) -> String {
+        match self {
+            Self::ConfigurationLoadFailed { .. } => {
+                "Could not load config from cluster".to_string()
+            }
+            Self::CollectionNotFound { .. } => "Collection unknown".to_string(),
+            Self::CollectionUnknownDuringRequest { .. } => {
+                "Collection unknown during request".to_string()
+            }
+            Self::ClusterNotContactable { .. } => "Cluster not contactable".to_string(),
+            Self::ScopeNotFound { .. } => "Scope unknown".to_string(),
+            Self::KeyNotFound { .. } => "Key not found".to_string(),
+            Self::KeyAlreadyExists { .. } => "Key already exists".to_string(),
+            Self::AccessError { .. } => "Access error".to_string(),
+            Self::AuthError { .. } => "Authentication error".to_string(),
+            Self::Timeout { .. } => "Timeout".to_string(),
+            Self::Cancelled { .. } => "Request cancelled".to_string(),
+            Self::CapellaClusterNotFound { .. } => "Cluster not found".to_string(),
+            Self::RequestFailed { .. } => "Request failed".to_string(),
+        }
+    }
+
+    pub fn expanded_message(&self) -> String {
+        match self {
+            Self::ConfigurationLoadFailed { reason } => {
+                reason.to_string()
+            }
+            Self::CollectionNotFound {  name, scope_name, ..} => {
+                format!("Collection {}.{} unknown, do both the scope and collection exist?", scope_name, name)
+            },
+            Self::CollectionUnknownDuringRequest { key, cid } => {
+                format!("Collection with ID {} unknown during request for key {}. Were the collection or scope deleted?", cid, key)
+            },
+            Self::ClusterNotContactable { cluster, reason } => format!(
+                "Cluster ({}) not contactable ({}) - check server ports and cluster encryption setting.",
+                cluster,
+                reason
+            ),
+            Self::ScopeNotFound { name,.. } => {
+                format!("Scope {} unknown, does the scope exist?", name)
+            },
+            Self::KeyNotFound { key } => format!("Key {} was not found, does it exist in the specified collection?", key),
+            Self::KeyAlreadyExists { key } => format!("Key {} already exists, is the correct collection being used?", key),
+            Self::AccessError { reason } => {
+                if let Some(r) = reason {
+                    r.to_string()
+                } else {
+                    "access error".to_string()
+                }
+            }
+            Self::AuthError { reason } => {
+                if let Some(r) = reason {
+                    r.to_string()
+                } else {
+                    "authentication error".to_string()
+                }
+            }
+            Self::Timeout { key } => match key {
+                Some(k) => format!("Timeout was observed for key {}, check network latency. Does the timeout need to be longer? You can change it with cb-env timeouts", k),
+                None =>  format!("Timeout was observed, check network latency. Does the timeout need to be longer? You can change it with cb-env timeout")
+            }
+            Self::Cancelled { key } => match key {
+                Some(k) => format!("Request was cancelled for {}", k),
+                None =>  "Request was cancelled".to_string(),
+            }
+            Self::CapellaClusterNotFound { name } => format!("Cluster {} was not found within the Capella organisation", name),
+            Self::RequestFailed { reason, .. } => match reason.as_ref() {
+                Some(re) => re.to_string(),
+                None => "Request failed for an unspecified reason".to_string(),
+            },
+        }
+    }
+
+    pub fn try_parse_kv_fail_body(response: &mut KvResponse) -> Option<String> {
+        match response.body() {
+            Some(b) => match serde_json::from_slice::<KVErrorContext>(&*b) {
+                Ok(context) => context.context,
+                Err(_) => None,
+            },
+            None => None,
+        }
+    }
+
+    pub fn make_kv_doc_op_error(
+        status: Status,
+        reason: Option<String>,
+        key: String,
+        cid: u32,
+    ) -> Self {
+        match status {
+            Status::AuthError => ClientError::AuthError { reason },
+            Status::AccessError => ClientError::AccessError { reason },
+            Status::KeyNotFound => ClientError::KeyNotFound { key },
+            Status::KeyExists => ClientError::KeyAlreadyExists { key },
+            Status::CollectionUnknown => ClientError::CollectionUnknownDuringRequest { key, cid },
+            _ => ClientError::RequestFailed {
+                reason: Some(status.as_string()),
+                key: Some(key),
+            },
         }
     }
 }
 
 impl fmt::Display for ClientError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let message = match self {
-            Self::ConfigurationLoadFailed { reason } => match reason.as_ref() {
-                Some(re) => format!("failed to load config from cluster: {}", re),
-                None => "failed to load config from cluster".into(),
-            },
-            Self::CollectionManifestLoadFailed { reason } => match reason.as_ref() {
-                Some(re) => format!("failed to load collection manifest from cluster: {}", re),
-                None => "failed to load collection manifest from cluster".into(),
-            },
-            Self::CollectionNotFound { .. } => "collection not found".into(),
-            Self::ScopeNotFound { .. } => "scope not found".into(),
-            Self::KeyNotFound { .. } => "key not found".into(),
-            Self::KeyAlreadyExists { .. } => "key already exists".into(),
-            Self::AccessError => "access error".into(),
-            Self::AuthError => "authentication error".into(),
-            Self::Timeout { .. } => "timeout".into(),
-            Self::Cancelled { .. } => "request cancelled".into(),
-            Self::ClusterNotFound { name } => format!("cluster not found: {}", name),
-            Self::RequestFailed { reason, .. } => match reason.as_ref() {
-                Some(re) => format!("request failed: {}", re),
-                None => "request failed".into(),
-            },
-        };
+        let message = self.message();
         write!(f, "{}", message)
-    }
-}
-
-impl From<ClientError> for ShellError {
-    fn from(ce: ClientError) -> Self {
-        // todo: this can definitely be improved with more detail and reporting specifics
-        ShellError::GenericError(ce.to_string(), ce.to_string(), None, None, Vec::new())
     }
 }
 
@@ -124,4 +239,9 @@ impl From<tokio::sync::oneshot::error::RecvError> for ClientError {
             key: None,
         }
     }
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct KVErrorContext {
+    pub context: Option<String>,
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -7,7 +7,6 @@ pub use crate::client::http_client::{
 pub use crate::client::http_handler::HttpResponse;
 pub use crate::client::kv_client::{KeyValueRequest, KvClient, KvResponse};
 use log::debug;
-use nu_protocol::{ShellError, Span};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -70,8 +69,7 @@ impl Client {
         bucket: String,
         deadline: Instant,
         ctrl_c: Arc<AtomicBool>,
-        span: Span,
-    ) -> Result<KvClient, ShellError> {
+    ) -> Result<KvClient, ClientError> {
         KvClient::connect(
             self.seeds.clone(),
             self.username.clone(),
@@ -82,18 +80,6 @@ impl Client {
             ctrl_c,
         )
         .await
-        .map_err(|e| {
-            ShellError::GenericError(
-                format!("Failed to connect to cluster: {}", e),
-                format!(
-                    "Check server ports and cluster encryption setting. Does the bucket {} exist?",
-                    bucket
-                ),
-                Some(span),
-                None,
-                Vec::new(),
-            )
-        })
     }
 
     fn try_lookup_srv(addr: String) -> Result<Vec<String>, ClientError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 #![recursion_limit = "256"]
 
+extern crate core;
+
 mod cli;
 mod client;
 mod config;

--- a/tests/integration/tests/doc_get.rs
+++ b/tests/integration/tests/doc_get.rs
@@ -35,7 +35,7 @@ pub async fn test_get_a_document_not_found(cluster: Arc<ClusterUnderTest>) -> bo
             let out = cbsh!(cwd: dirs.test(), pipeline(r#"doc get "get_a_document_not_found" | get error | first"#));
 
             assert_eq!("", out.err);
-            assert!(out.out.contains("key not found"));
+            assert!(out.out.contains("Key not found"));
         },
     );
 

--- a/tests/integration/tests/doc_insert.rs
+++ b/tests/integration/tests/doc_insert.rs
@@ -54,7 +54,7 @@ pub async fn test_should_error_on_insert_twice(cluster: Arc<ClusterUnderTest>) -
             assert_eq!(0, json["success"]);
             assert_eq!(1, json["processed"]);
             assert_eq!(1, json["failed"]);
-            assert_eq!("key already exists", json["failures"]);
+            assert_eq!("Key already exists", json["failures"]);
         },
     );
 

--- a/tests/integration/tests/doc_remove.rs
+++ b/tests/integration/tests/doc_remove.rs
@@ -52,7 +52,7 @@ pub async fn test_should_error_on_remove_doc_not_found(cluster: Arc<ClusterUnder
             assert_eq!(0, json["success"]);
             assert_eq!(1, json["processed"]);
             assert_eq!(1, json["failed"]);
-            assert_eq!("key not found", json["failures"]);
+            assert_eq!("Key not found", json["failures"]);
         },
     );
 


### PR DESCRIPTION
Rework client package to not have references to nushell, making wrapping any ClientErrors the responsibility of the cli package. Add message() and expanded_message() to ClientError to facilitate conversion from ClientError to ShellError.
Improve the messages and error details for ClientError. Add a halt-on-error flag to doc commands to facilitate scripting where error codes might be wanted.