### PR TITLE
Add a Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git/
+target/
+log/
+.vscode/
+tests/integration/testgenerator/linux/testgenerator
+tests/integration/testgenerator/macos/testgenerator
+tests/integration/testgenerator/windows/testgenerator.exe
+/examples
+/.github
+/jupyter

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM rust:1.66.1 AS chef 
+# We only pay the installation cost once, 
+# it will be cached from the second build onwards
+RUN cargo install cargo-chef 
+WORKDIR /app
+
+
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare  --recipe-path recipe.json
+
+
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --recipe-path recipe.json
+# Build application
+COPY . .
+RUN cargo build --release
+
+
+
+FROM gcr.io/distroless/cc:nonroot
+COPY --from=builder /app/target/release/cbsh /
+ENTRYPOINT ["/cbsh"]


### PR DESCRIPTION
Motivation
----------
Allow generation of Docker image which may be used within Kubernetes to manage Couchbase clusters where there is no network access from the developer's PC.

Modifications
-------------
Add a multi-stage Dockerfile.

Results
-------
A Docker image may be easily generated. This doesn't implement any CI/CD or publishing of the Docker image to Docker Hub.