### PR TITLE
Change TLS trust store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       with:
         command: build
         # We build windows as a release build as debug builds are stack overflowing on startup.
-        args: --verbose --release --target ${{ matrix.target }} --features static-link-openssl
+        args: --verbose --release --target ${{ matrix.target }}
       env:
         VCPKGRS_DYNAMIC: 1
         RUSTFLAGS: -Ctarget-feature=+crt-static

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: --verbose --release --features static-link-openssl
+        args: --verbose --release
       env:
         VCPKGRS_DYNAMIC: 1
         RUSTFLAGS: -Ctarget-feature=+crt-static

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,7 +975,6 @@ dependencies = [
  "reqwest",
  "rpassword",
  "rust-embed",
- "rustls-native-certs",
  "rustls-pemfile",
  "serde",
  "serde_derive",
@@ -995,6 +994,7 @@ dependencies = [
  "trust-dns-resolver",
  "url",
  "uuid",
+ "webpki-roots 0.25.1",
 ]
 
 [[package]]
@@ -2155,15 +2155,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.2"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
+ "futures-util",
  "http",
  "hyper",
- "rustls 0.20.8",
+ "rustls 0.21.7",
  "tokio",
- "tokio-rustls 0.23.4",
+ "tokio-rustls 0.24.0",
 ]
 
 [[package]]
@@ -3669,9 +3670,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.25.2+1.1.1t"
+version = "111.27.0+1.1.1v"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320708a054ad9b3bf314688b5db87cf4d6683d64cfc835e2337924ae62bf4431"
+checksum = "06e8f197c82d7511c5b014030c9b1efeda40d7d5f99d23b4ceed3524a5e63f02"
 dependencies = [
  "cc",
 ]
@@ -4598,9 +4599,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.14"
+version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -4621,21 +4622,21 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.20.8",
+ "rustls 0.21.7",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.23.4",
+ "tokio-rustls 0.24.0",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
- "winreg 0.10.1",
+ "webpki-roots 0.25.1",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -4844,26 +4845,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.0"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07180898a28ed6a7f7ba2311594308f595e3dd2e3c3812fa0a80a47b45f17e5d"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
  "rustls-webpki",
  "sct",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -4877,9 +4866,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.100.1"
+version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring",
  "untrusted",
@@ -5821,7 +5810,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
 dependencies = [
- "rustls 0.21.0",
+ "rustls 0.21.7",
  "tokio",
 ]
 
@@ -5976,7 +5965,7 @@ dependencies = [
  "tokio-rustls 0.23.4",
  "tracing",
  "trust-dns-proto",
- "webpki-roots",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -6452,6 +6441,12 @@ checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9c6eda1c830a36f361e7721c87fd79ea84293b54f8c48c959f85ec636f0f196"
 
 [[package]]
 name = "wepoll-ffi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ reqwest = { version = "0.11", features = ["json", "rustls-tls", "blocking"] }
 rpassword = "7.0.0"
 rust-embed = "6.3"
 rustls-pemfile = "1.0.0"
-rustls-native-certs = "0.6.2"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
@@ -65,8 +64,9 @@ toml = "0.7.3"
 trust-dns-resolver = { version = "0.22.0", features = ["dns-over-rustls"] }
 url = "2.1"
 uuid = { version = "1.1.2", features = ["v4"] }
+webpki-roots = "0.25.1"
 
-[target.'cfg(not(target_os = "macos"))'.dependencies]
+[target.'cfg(not(any(target_os = "macos", target_os = "windows")))'.dependencies]
 # Our dependencies don't use OpenSSL on Macos
 openssl = { version = "0.10.48", features = ["vendored"], optional=true }
 
@@ -79,8 +79,8 @@ nu-test-support = { version = "0.83.1"}
 strum = "0.24.1"
 strum_macros = "0.24.3"
 
-[features]
 
+[features]
 # Enable to statically link OpenSSL; otherwise the system version will be used. Not enabled by default because it takes a while to build
 static-link-openssl = ["dep:openssl"]
 

--- a/src/cli/cbenv_managed.rs
+++ b/src/cli/cbenv_managed.rs
@@ -58,7 +58,7 @@ fn clusters(
         .map(|(k, v)| {
             let mut collected = NuValueMap::default();
             collected.add_bool("active", k == &active, span);
-            collected.add_bool("tls", v.tls_config().enabled(), span);
+            collected.add_bool("tls", v.tls_config().is_some(), span);
             collected.add_string("identifier", k.clone(), span);
             collected.add_string("username", String::from(v.username()), span);
             collected.add_string(

--- a/src/cli_options.rs
+++ b/src/cli_options.rs
@@ -23,6 +23,7 @@ pub struct CliOptions {
     pub no_motd: bool,
     pub disable_tls: bool,
     pub tls_cert_path: Option<String>,
+    pub tls_accept_all_certs: bool,
     pub config_path: Option<String>,
     pub logger_prefix: Option<String>,
     pub display_name: Option<String>,
@@ -223,6 +224,7 @@ pub fn parse_commandline_args(
             let display_name: Option<String> =
                 call.get_flag(context, &mut stack, "display-name")?;
             let no_config_prompt = call.has_flag("disable-config-prompt");
+            let tls_accept_all_certs = call.has_flag("tls-accept-all-certs");
 
             fn extract_contents(
                 expression: Option<Expression>,
@@ -296,6 +298,7 @@ pub fn parse_commandline_args(
                 logger_prefix,
                 display_name,
                 no_config_prompt,
+                tls_accept_all_certs,
             });
         }
     }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -7,13 +7,13 @@ pub use crate::client::http_client::{
 };
 pub use crate::client::http_handler::HttpResponse;
 pub use crate::client::kv_client::{KeyValueRequest, KvClient, KvResponse};
+pub use crate::client::tls::RustTlsConfig;
 use log::debug;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use tokio::time::Instant;
 
-use crate::config::ClusterTlsConfig;
 use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
 use trust_dns_resolver::Resolver;
 
@@ -27,12 +27,13 @@ mod http_handler;
 mod kv;
 mod kv_client;
 mod protocol;
+mod tls;
 
 pub struct Client {
     seeds: Vec<String>,
     username: String,
     password: String,
-    tls_config: ClusterTlsConfig,
+    tls_config: Option<RustTlsConfig>,
 }
 
 impl Client {
@@ -40,7 +41,7 @@ impl Client {
         seeds: Vec<String>,
         username: String,
         password: String,
-        tls_config: ClusterTlsConfig,
+        tls_config: Option<RustTlsConfig>,
     ) -> Self {
         let seeds = if Client::might_be_srv(&seeds) {
             Client::try_lookup_srv(seeds[0].clone()).unwrap_or(seeds)

--- a/src/client/tls.rs
+++ b/src/client/tls.rs
@@ -1,0 +1,155 @@
+use crate::client::capella_ca::CAPELLA_CERT;
+use crate::client::ClientError;
+use crate::ClusterTlsConfig;
+use log::{debug, error};
+use rustls_pemfile::{read_all, Item};
+use std::convert::TryFrom;
+use std::fs;
+use std::io::BufReader;
+use std::sync::Arc;
+use std::time::SystemTime;
+use tokio_rustls::rustls::client::{ServerCertVerified, ServerCertVerifier};
+use tokio_rustls::rustls::{
+    Certificate, ClientConfig, Error, OwnedTrustAnchor, RootCertStore, ServerName,
+};
+
+struct InsecureCertVerifier {}
+
+impl ServerCertVerifier for InsecureCertVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &Certificate,
+        _intermediates: &[Certificate],
+        _server_name: &ServerName,
+        _scts: &mut dyn Iterator<Item = &[u8]>,
+        _ocsp_response: &[u8],
+        _now: SystemTime,
+    ) -> Result<ServerCertVerified, Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+}
+
+#[derive(Clone)]
+pub struct RustTlsConfig {
+    config: ClientConfig,
+    // We need to hold onto these so that we can later rewrite them into the config file if needed.
+    accept_all_certs: bool,
+    cert_path: Option<String>,
+}
+
+impl RustTlsConfig {
+    pub fn new(
+        accept_all_certs: bool,
+        cert_path: Option<String>,
+    ) -> Result<RustTlsConfig, ClientError> {
+        let builder = ClientConfig::builder().with_safe_defaults();
+        if accept_all_certs {
+            let config = builder
+                .with_custom_certificate_verifier(Arc::new(InsecureCertVerifier {}))
+                .with_no_client_auth();
+
+            return Ok(RustTlsConfig {
+                config,
+                accept_all_certs,
+                cert_path,
+            });
+        }
+
+        let mut root_cert_store = RootCertStore::empty();
+        if let Some(path) = cert_path.clone() {
+            // If the user has provided a cert path then use it.
+            // If any errors occurs then consider this as fatal and return the error.
+            let cert = fs::read(path).map_err(ClientError::from)?;
+            let mut reader = BufReader::new(&cert[..]);
+            let items = read_all(&mut reader).map_err(|e| ClientError::RequestFailed {
+                reason: Some(format!("Failed to read cert file {}", e)),
+                key: None,
+            })?;
+            for item in items {
+                match item {
+                    Item::X509Certificate(c) => {
+                        root_cert_store.add(&Certificate(c)).map_err(|e| {
+                            ClientError::RequestFailed {
+                                reason: Some(format!("Failed to add cert to root store {}", e)),
+                                key: None,
+                            }
+                        })?
+                    }
+                    _ => {
+                        return Err(ClientError::RequestFailed {
+                            reason: Some("Unsupported certificate format".to_string()),
+                            key: None,
+                        })
+                    }
+                }
+            }
+        } else {
+            debug!("Adding webpki tls server roots");
+            root_cert_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
+                OwnedTrustAnchor::from_subject_spki_name_constraints(
+                    ta.subject,
+                    ta.spki,
+                    ta.name_constraints,
+                )
+            }));
+
+            debug!("Adding Capella root CA to trust store");
+            let mut reader = BufReader::new(CAPELLA_CERT.as_bytes());
+            match read_all(&mut reader) {
+                Ok(items) => {
+                    // There is only 1 item in the capella cert.
+                    match &items[0] {
+                        Item::X509Certificate(c) => {
+                            match root_cert_store.add(&Certificate(c.to_owned())) {
+                                Ok(()) => {}
+                                Err(e) => {
+                                    error!("Failed to add root capella cert to root store {}", e);
+                                }
+                            }
+                        }
+                        _ => {
+                            error!(
+                                "Failed to read capella certificate, unsupported certificate format"
+                            );
+                        }
+                    };
+                }
+                Err(e) => {
+                    error!("Failed to read capella certificate, {}", e);
+                }
+            };
+        };
+        let config = builder
+            .with_root_certificates(root_cert_store)
+            .with_no_client_auth();
+
+        Ok(RustTlsConfig {
+            config,
+            accept_all_certs,
+            cert_path,
+        })
+    }
+
+    pub fn config(&self) -> ClientConfig {
+        self.config.clone()
+    }
+
+    pub fn accept_all_certs(&self) -> bool {
+        self.accept_all_certs
+    }
+
+    pub fn cert_path(&self) -> Option<String> {
+        self.cert_path.clone()
+    }
+}
+
+impl TryFrom<ClusterTlsConfig> for RustTlsConfig {
+    type Error = ClientError;
+
+    fn try_from(tls_config: ClusterTlsConfig) -> Result<Self, Self::Error> {
+        RustTlsConfig::new(
+            tls_config.accept_all_certs(),
+            tls_config.cert_path().clone(),
+        )
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -424,6 +424,20 @@ impl From<(String, &RemoteCluster)> for ClusterConfig {
     fn from(cluster: (String, &RemoteCluster)) -> Self {
         let cloud = cluster.1.capella_org();
 
+        let tls_config = if let Some(tls_config) = cluster.1.tls_config() {
+            ClusterTlsConfig {
+                enabled: true,
+                cert_path: tls_config.cert_path(),
+                accept_all_certs: tls_config.accept_all_certs(),
+            }
+        } else {
+            ClusterTlsConfig {
+                enabled: false,
+                cert_path: None,
+                accept_all_certs: false,
+            }
+        };
+
         Self {
             identifier: cluster.0,
             conn_string: cluster.1.hostnames().join(","),
@@ -438,7 +452,7 @@ impl From<(String, &RemoteCluster)> for ClusterConfig {
                 management_timeout: Some(cluster.1.timeouts().management_timeout()),
                 transaction_timeout: Some(cluster.1.timeouts().transaction_timeout()),
             },
-            tls: cluster.1.tls_config().clone(),
+            tls: tls_config,
             credentials: ClusterCredentials {
                 username: Some(cluster.1.username().to_string()),
                 password: Some(cluster.1.password().to_string()),

--- a/src/remote_cluster.rs
+++ b/src/remote_cluster.rs
@@ -1,6 +1,6 @@
-use crate::client::{Client, CAPELLA_SRV_SUFFIX};
+use crate::client::{Client, RustTlsConfig, CAPELLA_SRV_SUFFIX};
 use crate::{
-    ClusterTlsConfig, DEFAULT_ANALYTICS_TIMEOUT, DEFAULT_DATA_TIMEOUT, DEFAULT_MANAGEMENT_TIMEOUT,
+    DEFAULT_ANALYTICS_TIMEOUT, DEFAULT_DATA_TIMEOUT, DEFAULT_MANAGEMENT_TIMEOUT,
     DEFAULT_QUERY_TIMEOUT, DEFAULT_SEARCH_TIMEOUT, DEFAULT_TRANSACTION_TIMEOUT,
 };
 use std::sync::{Arc, Mutex};
@@ -61,7 +61,7 @@ pub struct RemoteCluster {
     active_bucket: Mutex<Option<String>>,
     active_scope: Mutex<Option<String>>,
     active_collection: Mutex<Option<String>>,
-    tls_config: ClusterTlsConfig,
+    tls_config: Option<RustTlsConfig>,
     timeouts: Mutex<ClusterTimeouts>,
     capella_org: Option<String>,
     kv_batch_size: u32,
@@ -73,7 +73,7 @@ impl RemoteCluster {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         resources: RemoteClusterResources,
-        tls_config: ClusterTlsConfig,
+        tls_config: Option<RustTlsConfig>,
         timeouts: ClusterTimeouts,
         capella_org: Option<String>,
         kv_batch_size: u32,
@@ -155,7 +155,7 @@ impl RemoteCluster {
         self.password.as_str()
     }
 
-    pub fn tls_config(&self) -> &ClusterTlsConfig {
+    pub fn tls_config(&self) -> &Option<RustTlsConfig> {
         &self.tls_config
     }
 


### PR DESCRIPTION
Motivation
----------
We are currently using the native store to loads certs for use with kv. The native package has a dependency on OpenSSL which we don't want. We are allowing reqwest to load its default trust store that it uses for rusttls - webpki-roots. We should change both of these so that we load webpki-roots ourselves and set the config to use on reqwest - so that we control it and have better tracibility into versions being used as well as consistency across both HTTP and KV.

Changes
-------
Refactor TLS throughout so that TLS configs are only setup once per cluster entry in the config.
Refactor TLS so that HTTP and KV use the same TLS object type. Always uses webspki-roots as our trust store.