### PR TITLE
Fix format of timeout when querying search index

### DIFF
--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -1,7 +1,5 @@
 use crate::cli::error::{client_error_to_shell_error, unexpected_status_code_error};
-use crate::cli::util::{
-    cluster_identifiers_from, duration_to_golang_string, get_active_cluster, NuValueMap,
-};
+use crate::cli::util::{cluster_identifiers_from, get_active_cluster, NuValueMap};
 use crate::client::SearchQueryRequest;
 use crate::state::State;
 use log::debug;
@@ -92,7 +90,7 @@ fn run(
                 SearchQueryRequest::Execute {
                     query: query.clone(),
                     index: index.clone(),
-                    timeout: duration_to_golang_string(active_cluster.timeouts().search_timeout()),
+                    timeout: active_cluster.timeouts().search_timeout().as_millis(),
                 },
                 Instant::now().add(active_cluster.timeouts().search_timeout()),
                 ctrl_c.clone(),

--- a/src/client/http_client.rs
+++ b/src/client/http_client.rs
@@ -771,7 +771,7 @@ pub enum SearchQueryRequest {
     Execute {
         index: String,
         query: String,
-        timeout: String,
+        timeout: u128,
     },
 }
 


### PR DESCRIPTION
The fts service expects the timeout as an int in milliseconds. 