### PR TITLE
Update apt-get before installing packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             os: macos-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-        
+
     steps:
     - uses: actions/checkout@v3
 
@@ -46,9 +46,9 @@ jobs:
 
     - name: Setup Rust toolchain and cache
       uses: actions-rust-lang/setup-rust-toolchain@v1.4.3
-      
+
     - name: Install aarch64-linux gcc
-      run: sudo apt-get install gcc-aarch64-linux-gnu -y
+      run: sudo apt-get update && sudo apt-get install gcc-aarch64-linux-gnu -y
       if: matrix.target == 'aarch64-unknown-linux-gnu'
 
     - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       uses: actions-rust-lang/setup-rust-toolchain@v1.4.3
 
     - name: Install aarch64-linux gcc
-      run: sudo apt-get install gcc-aarch64-linux-gnu -y
+      run: sudo apt-get update &&  sudo apt-get install gcc-aarch64-linux-gnu -y
       if: matrix.target == 'aarch64-unknown-linux-gnu'
 
     - uses: SebRollen/toml-action@v1.0.1


### PR DESCRIPTION
Recent PRs have been failing due the the Build(aarch64-unknown-linux-gnu) job failing on `Install aarch64-linux gcc` with the following: 
```
Run sudo apt-get install gcc-aarch64-linux-gnu -y
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  binutils-aarch64-linux-gnu cpp-11-aarch64-linux-gnu cpp-aarch64-linux-gnu
  gcc-11-aarch64-linux-gnu gcc-11-aarch64-linux-gnu-base gcc-11-cross-base
  gcc-12-cross-base libasan6-arm64-cross libatomic1-arm64-cross
  libc6-arm64-cross libc6-dev-arm64-cross libgcc-11-dev-arm64-cross
  libgcc-s1-arm64-cross libgomp1-arm64-cross libhwasan0-arm64-cross
  libitm1-arm64-cross liblsan0-arm64-cross libstdc++6-arm64-cross
  libtsan0-arm64-cross libubsan1-arm64-cross linux-libc-dev-arm64-cross
Suggested packages:
  binutils-doc gcc-11-locales cpp-doc gcc-11-doc manpages-dev
  gdb-aarch64-linux-gnu gcc-doc
The following NEW packages will be installed:
  binutils-aarch64-linux-gnu cpp-11-aarch64-linux-gnu cpp-aarch64-linux-gnu
  gcc-11-aarch64-linux-gnu gcc-11-aarch64-linux-gnu-base gcc-11-cross-base
  gcc-12-cross-base gcc-aarch64-linux-gnu libasan6-arm64-cross
  libatomic1-arm64-cross libc6-arm64-cross libc6-dev-arm64-cross
  libgcc-11-dev-arm64-cross libgcc-s1-arm64-cross libgomp1-arm64-cross
  libhwasan0-arm64-cross libitm1-arm64-cross liblsan0-arm64-cross
  libstdc++6-arm64-cross libtsan0-arm64-cross libubsan1-arm64-cross
  linux-libc-dev-arm64-cross
0 upgraded, 22 newly installed, 0 to remove and 18 not upgraded.
Need to get 45.3 MB of archives.
After this operation, 155 MB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [142 B]
Get:2 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 gcc-11-aarch64-linux-gnu-base amd64 11.4.0-1ubuntu1~22.04cross1 [20.5 kB]
Get:3 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 cpp-11-aarch64-linux-gnu amd64 11.4.0-1ubuntu1~22.04cross1 [9421 kB]
Get:4 http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 cpp-aarch64-linux-gnu amd64 4:11.2.0-1ubuntu1 [3478 B]
Ign:5 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 binutils-aarch64-linux-gnu amd64 2.38-4ubuntu2.5
Get:6 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 gcc-11-cross-base all 11.4.0-1ubuntu1~22.04cross1 [15.5 kB]
Get:7 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 gcc-12-cross-base all 12.3.0-1ubuntu1~22.04cross1 [15.7 kB]
Get:8 http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libc6-arm64-cross all 2.35-0ubuntu1cross3 [1147 kB]
Ign:5 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 binutils-aarch64-linux-gnu amd64 2.38-4ubuntu2.5
Get:9 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libgcc-s1-arm64-cross all 12.3.0-1ubuntu1~22.04cross1 [39.8 kB]
Get:10 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libgomp1-arm64-cross all 12.3.0-1ubuntu1~22.04cross1 [122 kB]
Get:11 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libitm1-arm64-cross all 12.3.0-1ubuntu1~22.04cross1 [28.0 kB]
Get:12 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libatomic1-arm64-cross all 12.3.0-1ubuntu1~22.04cross1 [10.6 kB]
Ign:5 http://security.ubuntu.com/ubuntu jammy-updates/main amd64 binutils-aarch64-linux-gnu amd64 2.38-4ubuntu2.5
Err:5 mirror+file:/etc/apt/apt-mirrors.txt jammy-updates/main amd64 binutils-aarch64-linux-gnu amd64 2.38-4ubuntu2.5
  404  Not Found [IP: 52.252.75.106 80]
Get:13 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libasan6-arm64-cross all 11.4.0-1ubuntu1~22.04cross1 [2228 kB]
Get:14 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 liblsan0-arm64-cross all 12.3.0-1ubuntu1~22.04cross1 [1034 kB]
Get:15 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libtsan0-arm64-cross all 11.4.0-1ubuntu1~22.04cross1 [2223 kB]
Get:[16](https://github.com/couchbaselabs/couchbase-shell/actions/runs/8095613630/job/22124029307?pr=269#step:5:17) http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libstdc++6-arm64-cross all 12.3.0-1ubuntu1~22.04cross1 [616 kB]
Get:[17](https://github.com/couchbaselabs/couchbase-shell/actions/runs/8095613630/job/22124029307?pr=269#step:5:18) http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libubsan1-arm64-cross all 12.3.0-1ubuntu1~22.04cross1 [964 kB]
Get:[18](https://github.com/couchbaselabs/couchbase-shell/actions/runs/8095613630/job/22124029307?pr=269#step:5:19) http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libhwasan0-arm64-cross all 12.3.0-1ubuntu1~22.04cross1 [1117 kB]
Get:[19](https://github.com/couchbaselabs/couchbase-shell/actions/runs/8095613630/job/22124029307?pr=269#step:5:20) http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libgcc-11-dev-arm64-cross all 11.4.0-1ubuntu1~22.04cross1 [1147 kB]
Get:[20](https://github.com/couchbaselabs/couchbase-shell/actions/runs/8095613630/job/22124029307?pr=269#step:5:21) http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 gcc-11-aarch64-linux-gnu amd64 11.4.0-1ubuntu1~22.04cross1 [18.8 MB]
Get:[21](https://github.com/couchbaselabs/couchbase-shell/actions/runs/8095613630/job/22124029307?pr=269#step:5:22) http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 gcc-aarch64-linux-gnu amd64 4:11.2.0-1ubuntu1 [1242 B]
Get:[22](https://github.com/couchbaselabs/couchbase-shell/actions/runs/8095613630/job/22124029307?pr=269#step:5:23) http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 linux-libc-dev-arm64-cross all 5.15.0-22.22cross3 [1216 kB]
Get:[23](https://github.com/couchbaselabs/couchbase-shell/actions/runs/8095613630/job/22124029307?pr=269#step:5:24) http://azure.archive.ubuntu.com/ubuntu jammy/main amd64 libc6-dev-arm64-cross all 2.35-0ubuntu1cross3 [1546 kB]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/b/binutils/binutils-aarch64-linux-gnu_2.38-4ubuntu2.5_amd64.deb  404  Not Found [IP: 52.[25](https://github.com/couchbaselabs/couchbase-shell/actions/runs/8095613630/job/22124029307?pr=269#step:5:26)2.75.106 80]
Fetched [41](https://github.com/couchbaselabs/couchbase-shell/actions/runs/8095613630/job/22124029307?pr=269#step:5:42).7 MB in 2s (23.3 MB/s)
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```

This seems to be due to the apt index having become stale, this change makes the command fetch and re-index any available packages and should mitigate such issues in the future. 