### PR TITLE
Fix bucket flush enablement on creation/update

### DIFF
--- a/src/cli/buckets_create.rs
+++ b/src/cli/buckets_create.rs
@@ -98,12 +98,9 @@ fn buckets_create(
 
     let bucket_type: Option<String> = call.get_flag(engine_state, stack, "type")?;
     let replicas: Option<i64> = call.get_flag(engine_state, stack, "replicas")?;
-    let flush = call
-        .get_flag(engine_state, stack, "flush")?
-        .unwrap_or(false);
+    let flush = call.has_flag("flush");
     let durability: Option<String> = call.get_flag(engine_state, stack, "durability")?;
     let expiry: Option<i64> = call.get_flag(engine_state, stack, "expiry")?;
-
     debug!("Running buckets create for bucket {}", &name);
 
     let cluster_identifiers = cluster_identifiers_from(engine_state, stack, &state, call, true)?;

--- a/src/cli/buckets_update.rs
+++ b/src/cli/buckets_update.rs
@@ -49,7 +49,7 @@ impl Command for BucketsUpdate {
             )
             .named(
                 "flush",
-                SyntaxShape::String,
+                SyntaxShape::Boolean,
                 "whether to enable flush",
                 None,
             )
@@ -102,9 +102,7 @@ fn buckets_update(
     let name: String = call.req(engine_state, stack, 0)?;
     let ram: Option<i64> = call.get_flag(engine_state, stack, "ram")?;
     let replicas: Option<i64> = call.get_flag(engine_state, stack, "replicas")?;
-    let flush = call
-        .get_flag(engine_state, stack, "flush")?
-        .unwrap_or(false);
+    let flush = call.get_flag(engine_state, stack, "flush")?;
     let durability = call.get_flag(engine_state, stack, "durability")?;
     let expiry: Option<i64> = call.get_flag(engine_state, stack, "expiry")?;
 
@@ -201,7 +199,7 @@ fn update_bucket_settings(
     settings: &mut BucketSettings,
     ram: Option<u64>,
     replicas: Option<u64>,
-    flush: bool,
+    flush: Option<bool>,
     durability: Option<String>,
     expiry: Option<u64>,
     span: Span,
@@ -221,8 +219,8 @@ fn update_bucket_settings(
             }
         });
     }
-    if flush {
-        settings.set_flush_enabled(flush);
+    if let Some(f) = flush {
+        settings.set_flush_enabled(f);
     }
     if let Some(d) = durability {
         settings.set_minimum_durability_level(match DurabilityLevel::try_from(d.as_str()) {


### PR DESCRIPTION
Currently when creating a bucket we cannot supply a value for the flush flag, since it is a switch, however it is read as a flag, so always defaults to false. Also when updating a bucket the command takes a string, which cannot be converted to a bool, then the way the value is handled means that flush could only ever be enabled through the `buckets update` command, and not disabled.