### PR TITLE
Allow ids piped to doc commands to be ints

### DIFF
--- a/src/cli/doc_get.rs
+++ b/src/cli/doc_get.rs
@@ -255,6 +255,7 @@ pub(crate) fn ids_from_input(
         .into_interruptible_iter(Some(ctrl_c))
         .filter_map(move |v| match v {
             Value::String { val, .. } => Some(val),
+            Value::Int { val, .. } => Some(val.to_string()),
             Value::Record { val, .. } => {
                 if let Some(d) = val.get(id_column.clone()) {
                     match d {


### PR DESCRIPTION
Currently the ids piped into the doc and subdoc commands can only be strings, else no results are returned. We should also support the ids being ints so that we can do:
```
[11956 562] | subdoc get content
```
Instead of:
```
["11956" "562"] | subdoc get content
```