### PR TITLE
Return the prompt indicator

### DIFF
--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -32,15 +32,14 @@ def build_collection_prompt [] {
         "🗄"
     }
 
-    let prompt = $"('👤 ' + (ansi ub) + ($user) + (ansi reset) + ' 🏠 ' + (ansi yb) + ($cluster) + (ansi reset) + ' in ' + ($bucket_symbol) + ' ' + (ansi wb) + ($bucket_name) + ($collection_prompt) + (ansi reset))"
+    let prompt = $"('👤 ' + (ansi ub) + ($user) + (ansi reset) + ' 🏠 ' + (ansi yb) + ($cluster) + (ansi reset) + ' in ' + ($bucket_symbol) + ' ' + (ansi wb) + ($bucket_name) + ($collection_prompt) + (ansi reset))
+
+"
 
     $prompt
 }
 
 $env.PROMPT_COMMAND = {build_collection_prompt}
-
-$env.PROMPT_INDICATOR = "
-> "
 
 $env.PROMPT_COMMAND_RIGHT = ""
 $env.config = {

--- a/docs/sample_config/default_config_windows.nu
+++ b/docs/sample_config/default_config_windows.nu
@@ -26,15 +26,14 @@ def build_collection_prompt [] {
        }
     }
 
-    let prompt = $"(($user) + ' at ' + ($cluster) + ' in ' + ($bucket_name) + ($collection_prompt))"
+    let prompt = $"(($user) + ' at ' + ($cluster) + ' in ' + ($bucket_name) + ($collection_prompt))
+
+"
 
     $prompt
 }
 
 $env.PROMPT_COMMAND = {build_collection_prompt}
-
-$env.PROMPT_INDICATOR = "
-> "
 
 $env.PROMPT_COMMAND_RIGHT = ""
 


### PR DESCRIPTION
Somewhere along the way we lost the prompt indicator, likely in the upgrade, although I couldn't find any changes to the PROMP_INDICATOR flag documented. This change alters the script that initialises the prompt to restore cbshell to the previous look. 

Before:
```
👤 Administrator 🏠 local in 🗄 <not-set>

```

After: 
```
👤 Administrator 🏠 local in 🗄 <not-set>
>
```