### PR TITLE
Remove notset in UI

### DIFF
--- a/docs/sample_config/default_config.nu
+++ b/docs/sample_config/default_config.nu
@@ -8,31 +8,36 @@ def build_collection_prompt [] {
     let collection = $"($content | get collection)"
     let cluster_type = $"($content | get cluster_type)"
 
-    let bucket_name = if $bucket == "" {
-        "<not-set>"
-    } else {
-        $bucket
-    }
-
-    let collection_prompt = if $bucket_name == "" or ($scope == "" and $collection == "") {
-        ""
-    } else {
-        if $scope != "" and $collection == "" {
-            '.' + ($scope) + '.<notset>'
-        } else if $scope == "" and $collection != "" {
-            '.<notset>.' + ($collection)
-       } else {
-            '.' + ($scope) + '.' + ($collection)
-       }
-    }
-
-    let bucket_symbol = if $cluster_type == "provisioned" {
+ let bucket_symbol = if $cluster_type == "provisioned" {
         "☁️"
     } else {
         "🗄"
     }
 
-    let prompt = $"('👤 ' + (ansi ub) + ($user) + (ansi reset) + ' 🏠 ' + (ansi yb) + ($cluster) + (ansi reset) + ' in ' + ($bucket_symbol) + ' ' + (ansi wb) + ($bucket_name) + ($collection_prompt) + (ansi reset))
+    let bucket_prompt = if $bucket == "" {
+        ""
+    } else {
+       ' in ' + ($bucket_symbol) + ' ' + (ansi wb) + ($bucket)
+    }
+
+    let collection_prompt = if $bucket_prompt == "" {
+        ""
+    } else {
+        let scope_name = if $scope == "" {
+            '._default'
+        } else {
+            '.' + $scope
+        }
+
+        let col_name = if $collection == "" {
+            '._default'
+        } else {
+            '.' + $collection
+        }
+        $"($scope_name + $col_name)"
+    }
+
+    let prompt = $"('👤 ' + (ansi ub) + ($user) + (ansi reset) + ' 🏠 ' + (ansi yb) + ($cluster) + (ansi reset) + ($bucket_prompt) + ($collection_prompt) + (ansi reset))
 
 "
 

--- a/docs/sample_config/default_config_windows.nu
+++ b/docs/sample_config/default_config_windows.nu
@@ -8,25 +8,31 @@ def build_collection_prompt [] {
     let collection = $"($content | get collection)"
     let cluster_type = $"($content | get cluster_type)"
 
+    let bucket_prompt =
     let bucket_name = if $bucket == "" {
-        "<not-set>"
-    } else {
-        $bucket
-    }
-
-    let collection_prompt = if $bucket_name == "" or ($scope == "" and $collection == "") {
         ""
     } else {
-        if $scope != "" and $collection == "" {
-            '.' + ($scope) + '.<notset>'
-        } else if $scope == "" and $collection != "" {
-            '.<notset>.' + ($collection)
-       } else {
-            '.' + ($scope) + '.' + ($collection)
-       }
+        ' in ' + ($bucket)
     }
 
-    let prompt = $"(($user) + ' at ' + ($cluster) + ' in ' + ($bucket_name) + ($collection_prompt))
+    let collection_prompt = if $bucket_prompt == "" {
+        ""
+    } else {
+        let scope_name = if $scope == "" {
+            '._default'
+        } else {
+            '.' + $scope
+        }
+
+        let col_name = if $collection == "" {
+            '._default'
+        } else {
+            '.' + $collection
+        }
+        $"($scope_name + $col_name)"
+    }
+
+    let prompt = $"(($user) + ' at ' + ($cluster) + ($bucket_prompt) + ($collection_prompt))
 
 "
 


### PR DESCRIPTION
Currently when a bucket/scope/collection is not set then the ui shows<not-set> in the command prompt. This has been changed so that when a bucket is not set, nothing is shown or when a scope or collection is not set the we show `_default`:
```
[INFO] 2024-04-15 13:03:45.205 Thanks for trying CBSH!
👤 Administrator 🏠 local
> cb-env bucket travel-sample
╭────────┬───────────────╮
│ bucket │ travel-sample │
╰────────┴───────────────╯
👤 Administrator 🏠 local in 🗄 travel-sample._default._default
> cb-env collection landmark
╭────────────┬──────────╮
│ collection │ landmark │
╰────────────┴──────────╯
👤 Administrator 🏠 local in 🗄 travel-sample._default.landmark
> cb-env scope inventory
╭───────┬───────────╮
│ scope │ inventory │
╰───────┴───────────╯
👤 Administrator 🏠 local in 🗄 travel-sample.inventory.landmark
>
```