### PR TITLE
Remove index name from vector search results

### DIFF
--- a/src/cli/vector_search.rs
+++ b/src/cli/vector_search.rs
@@ -247,7 +247,6 @@ fn run(
             let mut collected = NuValueMap::default();
             collected.add_string("id", row.id, span);
             collected.add_string("score", format!("{}", row.score), span);
-            collected.add_string("index", row.index, span);
             collected.add_string("cluster", identifier.clone(), span);
 
             results.push(collected.into_value(span));
@@ -273,7 +272,6 @@ fn index_name_from_namespace(index: String, namespace: (String, String, String))
 #[derive(Debug, Deserialize)]
 struct SearchResultHit {
     score: f32,
-    index: String,
     id: String,
 }
 


### PR DESCRIPTION
Currently we print the index name as part of the results from the vector search command. These names can be very long, which can result in the following if the index name alone cannot fit onto the width of the terminal (in this example the terminal was half the screen): 

```
👤 Administrator 🏠 local in 🗄 default._default._default
> subdoc get contentVector 10022 | select content | vector search landmark-content-index contentVector --neighbours 5
Couldn't fit table into 121 columns!
```

Therefore this PR is to remove the index names, allowing the results to be displayed as follows on the same terminal:

```
> subdoc get contentVector 10022 | select content | vector search landmark-content-index contentVector --neighbours 5
╭───┬───────┬─────────────────────────────────────────┬─────────╮
│ # │  id   │                  score                  │ cluster │
├───┼───────┼─────────────────────────────────────────┼─────────┤
│ 0 │ 10022 │ 340282350000000000000000000000000000000 │ local   │
│ 1 │ 16464 │ 1.7499461                               │ local   │
│ 2 │ 1505  │ 1.585367                                │ local   │
│ 3 │ 4944  │ 1.5157926                               │ local   │
│ 4 │ 26195 │ 1.3171678                               │ local   │
╰───┴───────┴─────────────────────────────────────────┴─────────╯
```

