### PR TITLE
Fix formatting of data prior to import

### DIFF
--- a/src/cli/doc_import.rs
+++ b/src/cli/doc_import.rs
@@ -117,13 +117,13 @@ fn run_import(
 
             if let Value::Record { val, .. } = i {
                 let mut id = None;
-                let mut content = vec![];
+                let mut content = serde_json::Map::new();
                 for (k, v) in val.iter() {
                     if k.clone() == id_column {
                         id = v.as_str().ok();
                     }
 
-                    content.push(convert_nu_value_to_json_value(&v, span).ok()?);
+                    content.insert(k.clone(), convert_nu_value_to_json_value(&v, span).ok()?);
                 }
                 if let Some(i) = id {
                     return Some((i.to_string(), content));
@@ -131,7 +131,10 @@ fn run_import(
             }
             None
         })
-        .collect::<Vec<(String, Vec<serde_json::Value>)>>();
+        .collect::<Vec<(
+            String,
+            serde_json::Map<std::string::String, serde_json::Value>,
+        )>>();
 
     let mut all_items = vec![];
     for item in filtered {


### PR DESCRIPTION
Doc import has not been working as intended due to incorrect formatting of the data prior to uploading into couchbase. This PR fixes that. 

👤 Administrator 🏠 local in 🗄 default._default._default
> cat user.json
{
  "name": "Michael",
  "age": 32,
  "height": 180
}
👤 Administrator 🏠 local in 🗄 default._default._default
> doc import user.json --id-column name
╭───┬───────────┬─────────┬────────┬──────────┬─────────╮
│ # │ processed │ success │ failed │ failures │ cluster │
├───┼───────────┼─────────┼────────┼──────────┼─────────┤
│ 0 │         1 │       1 │      0 │          │ local   │
╰───┴───────────┴─────────┴────────┴──────────┴─────────╯
👤 Administrator 🏠 local in 🗄 default._default._default
> doc get Michael
╭───┬─────────┬──────────────────────┬─────────────────────┬───────┬─────────╮
│ # │   id    │       content        │         cas         │ error │ cluster │
├───┼─────────┼──────────────────────┼─────────────────────┼───────┼─────────┤
│ 0 │ Michael │ ╭────────┬─────────╮ │ 1713353069505150976 │       │ local   │
│   │         │ │ name   │ Michael │ │                     │       │         │
│   │         │ │ age    │ 32      │ │                     │       │         │
│   │         │ │ height │ 180     │ │                     │       │         │
│   │         │ ╰────────┴─────────╯ │                     │       │         │
╰───┴─────────┴──────────────────────┴─────────────────────┴───────┴─────────╯