### PR TITLE
Add path not found error for subdoc get

### DIFF
--- a/src/client/kv.rs
+++ b/src/client/kv.rs
@@ -271,12 +271,19 @@ impl KvEndpoint {
         rx: Receiver<KvResponse>,
         key: String,
         cid: u32,
+        path: impl Into<Option<String>>,
     ) -> Result<KvResponse, ClientError> {
         let mut response = self.await_response(rx, key.clone()).await?;
         let status = response.status();
         if status != Status::Success {
             let reason = ClientError::try_parse_kv_fail_body(&mut response);
-            return Err(ClientError::make_kv_doc_op_error(status, reason, key, cid));
+            return Err(ClientError::make_kv_doc_op_error(
+                status,
+                reason,
+                key,
+                cid,
+                path.into(),
+            ));
         }
         Ok(response)
     }
@@ -343,7 +350,7 @@ impl KvEndpoint {
         let (tx, rx) = oneshot::channel::<KvResponse>();
         self.send(req, tx).await?;
 
-        self.await_and_handle_doc_response(rx, key, collection_id)
+        self.await_and_handle_doc_response(rx, key, collection_id, None)
             .await
     }
 
@@ -374,7 +381,7 @@ impl KvEndpoint {
         let (tx, rx) = oneshot::channel::<KvResponse>();
         self.send(req, tx).await?;
 
-        self.await_and_handle_doc_response(rx, key, collection_id)
+        self.await_and_handle_doc_response(rx, key, collection_id, path)
             .await
     }
 
@@ -421,7 +428,7 @@ impl KvEndpoint {
         let (tx, rx) = oneshot::channel::<KvResponse>();
         self.send(req, tx).await?;
 
-        self.await_and_handle_doc_response(rx, key, collection_id)
+        self.await_and_handle_doc_response(rx, key, collection_id, None)
             .await
     }
 
@@ -450,7 +457,7 @@ impl KvEndpoint {
         let (tx, rx) = oneshot::channel::<KvResponse>();
         self.send(req, tx).await?;
 
-        self.await_and_handle_doc_response(rx, key, collection_id)
+        self.await_and_handle_doc_response(rx, key, collection_id, None)
             .await
     }
 
@@ -479,7 +486,7 @@ impl KvEndpoint {
         let (tx, rx) = oneshot::channel::<KvResponse>();
         self.send(req, tx).await?;
 
-        self.await_and_handle_doc_response(rx, key, collection_id)
+        self.await_and_handle_doc_response(rx, key, collection_id, None)
             .await
     }
 
@@ -508,7 +515,7 @@ impl KvEndpoint {
         let (tx, rx) = oneshot::channel::<KvResponse>();
         self.send(req, tx).await?;
 
-        self.await_and_handle_doc_response(rx, key, collection_id)
+        self.await_and_handle_doc_response(rx, key, collection_id, None)
             .await
     }
 
@@ -532,7 +539,7 @@ impl KvEndpoint {
         let (tx, rx) = oneshot::channel::<KvResponse>();
         self.send(req, tx).await?;
 
-        self.await_and_handle_doc_response(rx, key, collection_id)
+        self.await_and_handle_doc_response(rx, key, collection_id, None)
             .await
     }
 

--- a/src/client/protocol.rs
+++ b/src/client/protocol.rs
@@ -504,6 +504,7 @@ pub enum Status {
     KeyExists,
     CollectionUnknown,
     ScopeUnknown,
+    PathNotFound,
     Unknown(u16),
 }
 
@@ -523,6 +524,7 @@ impl Status {
             Status::KeyExists => "key already exists".into(),
             Status::CollectionUnknown => "collection unknown".into(),
             Status::ScopeUnknown => "scope unknown".into(),
+            Status::PathNotFound => "field not found".into(),
             Status::Unknown(status) => format!("{:#04x}", status),
         }
     }
@@ -538,6 +540,7 @@ impl From<u16> for Status {
             0x8c => Status::ScopeUnknown,
             0x20 => Status::AuthError,
             0x24 => Status::AccessError,
+            0xc0 => Status::PathNotFound,
             _ => Status::Unknown(input),
         }
     }


### PR DESCRIPTION
Before this change, a missing path would result in the following: 
```
> subdoc get names landmark_10019
╭───┬────────────────┬─────────┬─────┬────────────────┬─────────╮
│ # │       id       │ content │ cas │     error      │ cluster │
├───┼────────────────┼─────────┼─────┼────────────────┼─────────┤
│ 0 │ landmark_10019 │         │   0 │ Request failed │ local   │
╰───┴────────────────┴─────────┴─────┴────────────────┴─────────╯
```

Now we get: 
```
> subdoc get names landmark_10019
╭───┬────────────────┬─────────┬─────┬────────────────┬─────────╮
│ # │       id       │ content │ cas │     error      │ cluster │
├───┼────────────────┼─────────┼─────┼────────────────┼─────────┤
│ 0 │ landmark_10019 │         │   0 │ Path not found │ local   │
╰───┴────────────────┴─────────┴─────┴────────────────┴─────────╯
```