### PR TITLE
Improve batching in Bedrock client

### DIFF
--- a/src/client/bedrock_client.rs
+++ b/src/client/bedrock_client.rs
@@ -18,7 +18,11 @@ impl BedrockClient {
 
     pub fn batch_chunks(&self, chunks: Vec<String>) -> Vec<Vec<String>> {
         // AWS Bedrock only support batch processing on data stored in S3 buckets so we have to process chunks one at a time
-        vec![chunks]
+        let mut batches: Vec<Vec<String>> = Vec::new();
+        for chunk in chunks {
+            batches.push(vec![chunk])
+        }
+        batches
     }
 
     pub async fn embed(


### PR DESCRIPTION
Embedding using the AWS SDK can only be done one string at a time. However the way that we currently batch the requests means that the user will just see:
`
Embedding batch 1/1
`
For some time, while all of the embeddings are individually retrieved. This change puts each of the strings to be embedded in a seperate batch, meaning that the user will see a steady stream of batches being embedded. 
```
Embedding batch 2668/4495
Embedding batch 2669/4495
Embedding batch 2670/4495
Embedding batch 2671/4495
Embedding batch 2672/4495
```