### PR TITLE
Print _default when scope and collection not set

### DIFF
--- a/src/cli/cbenv_cmd.rs
+++ b/src/cli/cbenv_cmd.rs
@@ -106,14 +106,16 @@ fn use_cmd(
                 );
                 results.add_string(
                     "scope",
-                    active.active_scope().unwrap_or_else(|| String::from("")),
+                    active
+                        .active_scope()
+                        .unwrap_or_else(|| String::from("_default")),
                     span,
                 );
                 results.add_string(
                     "collection",
                     active
                         .active_collection()
-                        .unwrap_or_else(|| String::from("")),
+                        .unwrap_or_else(|| String::from("_default")),
                     span,
                 );
                 results.add_string("cluster_type", active.cluster_type(), span);


### PR DESCRIPTION
Currently when run the cb-env command leaves the scope and collection field blank when none has been set. This is a little confusing since the prompt shows the scope and collection as `_default`. This PR changes the output of the cb-env command to make it consistent with the prompt.