### PR TITLE
Show active capella org in cbenv output when set

### DIFF
--- a/src/cli/cbenv_cmd.rs
+++ b/src/cli/cbenv_cmd.rs
@@ -25,11 +25,6 @@ impl Command for UseCmd {
     fn signature(&self) -> Signature {
         Signature::build("cb-env")
             .switch(
-                "capella",
-                "show default execution environment of capella",
-                None,
-            )
-            .switch(
                 "timeouts",
                 "show default execution environment for timeouts",
                 None,
@@ -59,108 +54,101 @@ fn use_cmd(
     call: &Call,
     _input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let show_capella = call.has_flag(engine_state, stack, "capella")?;
     let show_timeouts = call.has_flag(engine_state, stack, "timeouts")?;
 
     let span = call.head;
 
     let guard = state.lock().unwrap();
     let mut results = NuValueMap::default();
-    if show_capella {
-        let org = guard.active_capella_org()?;
 
-        results.add_string(
-            "capella-organisation",
-            guard
-                .active_capella_org_name()
-                .unwrap_or_else(|| String::from("")),
-            span,
-        );
-        results.add_string(
-            "project",
-            org.active_project().unwrap_or_else(|| String::from("")),
-            span,
-        );
-        if show_timeouts {
-            results.add_i64(
-                "management-timeout (ms)",
-                org.timeout().as_millis() as i64,
+    match guard.active_cluster() {
+        Some(active) => {
+            let display_name = if let Some(dn) = active.display_name() {
+                dn
+            } else {
+                active.username().to_string()
+            };
+            results.add_string("username", active.username(), span);
+            results.add_string("display_name", display_name, span);
+            results.add_string("cluster", guard.active(), span);
+            results.add_string(
+                "bucket",
+                active.active_bucket().unwrap_or_else(|| String::from("")),
                 span,
             );
-        }
-    } else {
-        match guard.active_cluster() {
-            Some(active) => {
-                let display_name = if let Some(dn) = active.display_name() {
-                    dn
-                } else {
-                    active.username().to_string()
-                };
-                results.add_string("username", active.username(), span);
-                results.add_string("display_name", display_name, span);
-                results.add_string("cluster", guard.active(), span);
-                results.add_string(
-                    "bucket",
-                    active.active_bucket().unwrap_or_else(|| String::from("")),
-                    span,
-                );
-                results.add_string(
-                    "scope",
-                    active
-                        .active_scope()
-                        .unwrap_or_else(|| String::from("_default")),
-                    span,
-                );
-                results.add_string(
-                    "collection",
-                    active
-                        .active_collection()
-                        .unwrap_or_else(|| String::from("_default")),
-                    span,
-                );
-                results.add_string("cluster_type", active.cluster_type(), span);
-                if let Some(co) = active.capella_org() {
-                    results.add_string("capella-organization", co, span);
-                }
 
-                if show_timeouts {
-                    let timeouts = active.timeouts();
-                    results.add_i64(
-                        "data-timeout (ms)",
-                        timeouts.data_timeout().as_millis() as i64,
-                        span,
-                    );
-                    results.add_i64(
-                        "management-timeout (ms)",
-                        timeouts.management_timeout().as_millis() as i64,
-                        span,
-                    );
-                    results.add_i64(
-                        "analytics-timeout (ms)",
-                        timeouts.analytics_timeout().as_millis() as i64,
-                        span,
-                    );
-                    results.add_i64(
-                        "query-timeout (ms)",
-                        timeouts.query_timeout().as_millis() as i64,
-                        span,
-                    );
-                    results.add_i64(
-                        "search-timeout (ms)",
-                        timeouts.search_timeout().as_millis() as i64,
-                        span,
-                    );
-                }
+            results.add_string(
+                "scope",
+                active.active_scope().unwrap_or_else(|| String::from("")),
+                span,
+            );
+            results.add_string(
+                "collection",
+                active
+                    .active_collection()
+                    .unwrap_or_else(|| String::from("")),
+                span,
+            );
+            results.add_string("cluster_type", active.cluster_type(), span);
+
+            results.add_string(
+                "cluster-organization",
+                active.capella_org().unwrap_or(String::from("")),
+                span,
+            );
+
+            if show_timeouts {
+                let timeouts = active.timeouts();
+                results.add_i64(
+                    "data-timeout (ms)",
+                    timeouts.data_timeout().as_millis() as i64,
+                    span,
+                );
+                results.add_i64(
+                    "management-timeout (ms)",
+                    timeouts.management_timeout().as_millis() as i64,
+                    span,
+                );
+                results.add_i64(
+                    "analytics-timeout (ms)",
+                    timeouts.analytics_timeout().as_millis() as i64,
+                    span,
+                );
+                results.add_i64(
+                    "query-timeout (ms)",
+                    timeouts.query_timeout().as_millis() as i64,
+                    span,
+                );
+                results.add_i64(
+                    "search-timeout (ms)",
+                    timeouts.search_timeout().as_millis() as i64,
+                    span,
+                );
             }
-            None => {
-                results.add_string("username", String::from(""), span);
-                results.add_string("display_name", String::from(""), span);
-                results.add_string("cluster", String::from(""), span);
-                results.add_string("bucket", String::from(""), span);
-                results.add_string("scope", String::from(""), span);
-                results.add_string("collection", String::from(""), span);
-                results.add_string("cluster_type", String::from(""), span);
-            }
+        }
+        None => {
+            results.add_string("username", String::from(""), span);
+            results.add_string("display_name", String::from(""), span);
+            results.add_string("cluster", String::from(""), span);
+            results.add_string("bucket", String::from(""), span);
+            results.add_string("scope", String::from(""), span);
+            results.add_string("collection", String::from(""), span);
+            results.add_string("cluster_type", String::from(""), span);
+        }
+    }
+
+    if let Some(active_org) = guard.active_capella_org_name() {
+        results.add_string("active-organization", active_org, span);
+        let (project, timeout) = match guard.active_capella_org() {
+            Ok(org) => (
+                org.active_project().unwrap_or_else(|| String::from("")),
+                org.timeout().as_millis() as i64,
+            ),
+            Err(_) => ("".to_string(), 0),
+        };
+        results.add_string("project", project, span);
+        if show_timeouts {
+            results.add_i64("management-timeout (ms)", timeout, span);
         }
     }
 


### PR DESCRIPTION
Currently when we run the cb-env command it only shows the capella org associated with the active cluster. This can lead to confusion since the org associated with the active cluster is not necessarily the same as the active org : 
```
> cb-env
╭──────────────────────┬───────────────╮
│ username             │ Administrator │
│ display_name         │ Westwooo      │
│ cluster              │ remote        │
│ bucket               │ default       │
│ scope                │ _default      │
│ collection           │ _default      │
│ cluster_type         │ other         │
│ capella-organization │ my-org        │
│ llm                  │ OpenAI        │
╰──────────────────────┴───────────────╯
👤 Westwooo 🏠 remote in 🗄 default._default._default
> projects
Error:   × Unexpected status code
   ╭─[entry #2:1:1]
 1 │ projects
   · ────┬───
   ·     ╰──
   ╰────
  help: Unexpected status code: 401, body: {"code":1001,"hint":"The request is unauthorized. Please ensure you have provided appropriate credentials in the request header. Please make sure the client IP that is trying to access the
        resource using the API key is in the API key allowlist.","httpStatusCode":401,"message":"Unauthorized"}


👤 Westwooo 🏠 remote in 🗄 default._default._default
> cb-env --capella
╭──────────────────────┬────────────╮
│ capella-organisation │ not-an-org │
│ project              │            │
│ llm                  │ OpenAI     │
╰──────────────────────┴────────────╯
```
It initially seems that we are unauthorised to connect to the org `my-org` however we can see that the active capella org is actually `not-an-org` which is the org used in the running of the projects command. To make this less confusing thisi PR removes the capella flag from cb-env and always shows the active org and differentiates it from the cluster org:
```
👤 Westwooo 🏠 remote in 🗄 default._default._default
> cb-env
╭──────────────────────┬───────────────╮
│ username             │ Administrator │
│ display_name         │ Westwooo      │
│ cluster              │ remote        │
│ bucket               │ default       │
│ scope                │               │
│ collection           │               │
│ cluster_type         │ other         │
│ cluster-organization │ my-org        │
│ active-organization  │ not-an-org    │
│ project              │               │
│ llm                  │ OpenAI        │
╰──────────────────────┴───────────────╯
```

Another solution considered was to make the cluster-organization of the active cluster the active-organization. But this means that we would be changing the active org when changing the active cluster, which doesn't feel right considering orgs are higher level entities than clusters. Also we want to have an active org without having to have an active cluster. 