### PR TITLE
Rename structs in cloud_json

### DIFF
--- a/src/cli/buckets_builder.rs
+++ b/src/cli/buckets_builder.rs
@@ -1,4 +1,4 @@
-use crate::client::cloud_json::JSONCloudsBucketsV4ResponseItem;
+use crate::client::cloud_json::Bucket;
 use serde_derive::Deserialize;
 use std::convert::TryFrom;
 use std::fmt;
@@ -314,10 +314,10 @@ impl TryFrom<JSONBucketSettings> for BucketSettings {
     }
 }
 
-impl TryFrom<&JSONCloudsBucketsV4ResponseItem> for BucketSettings {
+impl TryFrom<&Bucket> for BucketSettings {
     type Error = BuilderError;
 
-    fn try_from(settings: &JSONCloudsBucketsV4ResponseItem) -> Result<Self, Self::Error> {
+    fn try_from(settings: &Bucket) -> Result<Self, Self::Error> {
         Ok(BucketSettings {
             name: settings.name(),
             ram_quota_mb: settings.ram_quota(),

--- a/src/cli/clusters_create.rs
+++ b/src/cli/clusters_create.rs
@@ -1,4 +1,4 @@
-use crate::client::cloud_json::{JSONCloudCreateClusterRequestV4, Provider};
+use crate::client::cloud_json::{ClusterCreateRequest, Provider};
 use crate::state::State;
 use log::{debug, info};
 use std::convert::TryFrom;
@@ -110,7 +110,7 @@ fn clusters_create(
                 });
 
             let version = call.get_flag(engine_state, stack, "version")?;
-            JSONCloudCreateClusterRequestV4::new(name, provider, version, nodes)
+            ClusterCreateRequest::new(name, provider, version, nodes)
         }
         Value::String { val, .. } => {
             serde_json::from_str(val.as_str()).map_err(|e| serialize_error(e.to_string(), span))?

--- a/src/cli/util.rs
+++ b/src/cli/util.rs
@@ -6,8 +6,7 @@ use crate::cli::error::{
     malformed_response_error, no_active_bucket_error, unexpected_status_code_error,
 };
 use crate::cli::CBShellError::ClusterNotFound;
-use crate::client::cloud_json::JSONCloudsOrganizationsResponse;
-use crate::client::cloud_json::JSONCloudsProjectsResponse;
+use crate::client::cloud_json::{OrganizationsResponse, ProjectsResponse};
 use crate::client::{CapellaClient, CapellaRequest, HttpResponse};
 use crate::state::State;
 use crate::{RemoteCluster, RemoteClusterType};
@@ -343,7 +342,7 @@ pub(crate) fn find_project_id(
         }
         .into());
     }
-    let content: JSONCloudsProjectsResponse = serde_json::from_str(response.content())
+    let content: ProjectsResponse = serde_json::from_str(response.content())
         .map_err(|e| deserialize_error(e.to_string(), span))?;
 
     for p in content.items() {
@@ -372,7 +371,7 @@ pub(crate) fn find_org_id(
         }
         .into());
     }
-    let content: JSONCloudsOrganizationsResponse = serde_json::from_str(response.content())
+    let content: OrganizationsResponse = serde_json::from_str(response.content())
         .map_err(|e| deserialize_error(e.to_string(), span))?;
 
     let org = content.items().first().unwrap().id();

--- a/src/client/cloud.rs
+++ b/src/client/cloud.rs
@@ -1,7 +1,6 @@
 use crate::cli::CtrlcFuture;
 use crate::client::cloud_json::{
-    JSONCloudBucketsV4Response, JSONCloudClustersV4Response, JSONCloudsBucketsV4ResponseItem,
-    JSONCloudsClustersV4ResponseItem, JSONCloudsOrganizationsResponse, JSONCloudsProjectsResponse,
+    Bucket, BucketsResponse, Cluster, ClustersResponse, OrganizationsResponse, ProjectsResponse,
 };
 use crate::client::error::ClientError;
 use crate::client::http_handler::{HttpResponse, HttpVerb};
@@ -178,7 +177,7 @@ impl CapellaClient {
         &self,
         deadline: Instant,
         ctrl_c: Arc<AtomicBool>,
-    ) -> Result<JSONCloudsOrganizationsResponse, ClientError> {
+    ) -> Result<OrganizationsResponse, ClientError> {
         let request = CapellaRequest::GetOrganizations {};
         let response = self.capella_request(request, deadline, ctrl_c)?;
 
@@ -189,7 +188,7 @@ impl CapellaClient {
             });
         };
 
-        let resp: JSONCloudsOrganizationsResponse = serde_json::from_str(response.content())?;
+        let resp: OrganizationsResponse = serde_json::from_str(response.content())?;
         Ok(resp)
     }
 
@@ -198,7 +197,7 @@ impl CapellaClient {
         org_id: String,
         deadline: Instant,
         ctrl_c: Arc<AtomicBool>,
-    ) -> Result<JSONCloudsProjectsResponse, ClientError> {
+    ) -> Result<ProjectsResponse, ClientError> {
         let request = CapellaRequest::GetProjects { org_id };
         let response = self.capella_request(request, deadline, ctrl_c)?;
 
@@ -209,18 +208,21 @@ impl CapellaClient {
             });
         };
 
-        let resp: JSONCloudsProjectsResponse = serde_json::from_str(response.content())?;
+        let resp: ProjectsResponse = serde_json::from_str(response.content())?;
         Ok(resp)
     }
 
     pub fn create_project(
         &self,
         org_id: String,
-        payload: String,
+        name: String,
         deadline: Instant,
         ctrl_c: Arc<AtomicBool>,
     ) -> Result<(), ClientError> {
-        let request = CapellaRequest::CreateProject { org_id, payload };
+        let request = CapellaRequest::CreateProject {
+            org_id,
+            payload: format!("{{\"name\": \"{}\"}}", name),
+        };
         let response = self.capella_request(request, deadline, ctrl_c)?;
 
         if response.status() != 201 {
@@ -260,7 +262,7 @@ impl CapellaClient {
         project_id: String,
         deadline: Instant,
         ctrl_c: Arc<AtomicBool>,
-    ) -> Result<JSONCloudsClustersV4ResponseItem, ClientError> {
+    ) -> Result<Cluster, ClientError> {
         let request = CapellaRequest::GetClustersV4 { org_id, project_id };
         let response = self.capella_request(request, deadline, ctrl_c)?;
 
@@ -271,7 +273,7 @@ impl CapellaClient {
             });
         }
 
-        let resp: JSONCloudClustersV4Response = serde_json::from_str(response.content())?;
+        let resp: ClustersResponse = serde_json::from_str(response.content())?;
 
         for c in resp.items() {
             if c.name() == cluster_name {
@@ -288,7 +290,7 @@ impl CapellaClient {
         project_id: String,
         deadline: Instant,
         ctrl_c: Arc<AtomicBool>,
-    ) -> Result<JSONCloudClustersV4Response, ClientError> {
+    ) -> Result<ClustersResponse, ClientError> {
         let request = CapellaRequest::GetClustersV4 { org_id, project_id };
         let response = self.capella_request(request, deadline, ctrl_c)?;
 
@@ -299,7 +301,7 @@ impl CapellaClient {
             });
         }
 
-        let resp: JSONCloudClustersV4Response = serde_json::from_str(response.content())?;
+        let resp: ClustersResponse = serde_json::from_str(response.content())?;
         Ok(resp)
     }
 
@@ -359,7 +361,7 @@ impl CapellaClient {
         bucket: String,
         deadline: Instant,
         ctrl_c: Arc<AtomicBool>,
-    ) -> Result<JSONCloudsBucketsV4ResponseItem, ClientError> {
+    ) -> Result<Bucket, ClientError> {
         let request = CapellaRequest::GetBucketV4 {
             org_id,
             project_id,
@@ -375,7 +377,7 @@ impl CapellaClient {
             });
         }
 
-        let resp: JSONCloudsBucketsV4ResponseItem = serde_json::from_str(response.content())?;
+        let resp: Bucket = serde_json::from_str(response.content())?;
         Ok(resp)
     }
 
@@ -386,7 +388,7 @@ impl CapellaClient {
         cluster_id: String,
         deadline: Instant,
         ctrl_c: Arc<AtomicBool>,
-    ) -> Result<JSONCloudBucketsV4Response, ClientError> {
+    ) -> Result<BucketsResponse, ClientError> {
         let request = CapellaRequest::GetBucketsV4 {
             org_id,
             project_id,
@@ -401,7 +403,7 @@ impl CapellaClient {
             });
         }
 
-        let resp: JSONCloudBucketsV4Response = serde_json::from_str(response.content())?;
+        let resp: BucketsResponse = serde_json::from_str(response.content())?;
         Ok(resp)
     }
 

--- a/src/client/cloud_json.rs
+++ b/src/client/cloud_json.rs
@@ -3,67 +3,71 @@ use serde_derive::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
 #[derive(Debug, Deserialize)]
-pub(crate) struct JSONCloudBucketsV4Response {
-    data: Vec<JSONCloudsBucketsV4ResponseItem>,
+pub(crate) struct OrganizationsResponse {
+    data: Vec<Organization>,
 }
 
-impl JSONCloudBucketsV4Response {
-    pub fn items(self) -> Vec<JSONCloudsBucketsV4ResponseItem> {
-        self.data
+impl OrganizationsResponse {
+    pub fn items(&self) -> &Vec<Organization> {
+        self.data.as_ref()
     }
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct JSONCloudsBucketsV4ResponseItem {
+pub(crate) struct Organization {
+    id: String,
     name: String,
-    #[serde(alias = "type")]
-    bucket_type: String,
-    memory_allocation_in_mb: u64,
-    durability_level: String,
-    replicas: u32,
-    flush: bool,
-    time_to_live_in_seconds: u64,
 }
 
-impl JSONCloudsBucketsV4ResponseItem {
-    pub fn name(&self) -> String {
-        self.name.clone()
+impl Organization {
+    pub fn id(&self) -> &str {
+        &self.id
     }
-    pub fn ram_quota(&self) -> u64 {
-        self.memory_allocation_in_mb
-    }
-    pub fn flush(&self) -> bool {
-        self.flush
-    }
-    pub fn replicas(&self) -> u32 {
-        self.replicas
-    }
-    pub fn bucket_type(&self) -> String {
-        self.bucket_type.clone()
-    }
-    pub fn ttl_seconds(&self) -> u64 {
-        self.time_to_live_in_seconds
-    }
-    pub fn durability_level(&self) -> String {
-        self.durability_level.clone()
+    pub fn name(&self) -> &str {
+        &self.name
     }
 }
 
 #[derive(Debug, Deserialize)]
-pub(crate) struct JSONCloudClustersV4Response {
-    data: Vec<JSONCloudsClustersV4ResponseItem>,
+pub(crate) struct ProjectsResponse {
+    data: Vec<Project>,
 }
 
-impl JSONCloudClustersV4Response {
-    pub fn items(&self) -> Vec<JSONCloudsClustersV4ResponseItem> {
+impl ProjectsResponse {
+    pub fn items(&self) -> &Vec<Project> {
+        self.data.as_ref()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct Project {
+    id: String,
+    name: String,
+}
+
+impl Project {
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ClustersResponse {
+    data: Vec<Cluster>,
+}
+
+impl ClustersResponse {
+    pub fn items(&self) -> Vec<Cluster> {
         self.data.clone()
     }
 }
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct JSONCloudsClustersV4ResponseItem {
+pub(crate) struct Cluster {
     id: String,
     app_service_id: Option<String>,
     name: String,
@@ -159,76 +163,9 @@ pub(crate) struct AuditData {
     version: i32,
 }
 
-#[derive(Debug, Deserialize)]
-pub(crate) struct JSONCloudsOrganizationsResponse {
-    data: Vec<JSONCloudsOrganizationsResponseItem>,
-}
-
-impl JSONCloudsOrganizationsResponse {
-    pub fn items(&self) -> &Vec<JSONCloudsOrganizationsResponseItem> {
-        self.data.as_ref()
-    }
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct JSONCloudsOrganizationsResponseItem {
-    id: String,
-    name: String,
-}
-
-impl JSONCloudsOrganizationsResponseItem {
-    pub fn id(&self) -> &str {
-        &self.id
-    }
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct JSONCloudsProjectsResponseItem {
-    id: String,
-    name: String,
-    //     #[serde(rename = "tenantId")]
-    //     tenant_id: String,
-    //     #[serde(rename = "createdAt")]
-    //     created_at: String,
-}
-
-impl JSONCloudsProjectsResponseItem {
-    pub fn id(&self) -> &str {
-        &self.id
-    }
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct JSONCloudsProjectsResponse {
-    data: Vec<JSONCloudsProjectsResponseItem>,
-}
-
-impl JSONCloudsProjectsResponse {
-    pub fn items(&self) -> &Vec<JSONCloudsProjectsResponseItem> {
-        self.data.as_ref()
-    }
-}
-
-#[derive(Debug, Serialize)]
-pub(crate) struct JSONCloudCreateProjectRequest {
-    name: String,
-}
-
-impl JSONCloudCreateProjectRequest {
-    pub fn new(name: String) -> Self {
-        Self { name }
-    }
-}
-
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct JSONCloudCreateClusterRequestV4 {
+pub(crate) struct ClusterCreateRequest {
     name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
@@ -246,7 +183,7 @@ pub(crate) struct JSONCloudCreateClusterRequestV4 {
     cmek_id: Option<String>,
 }
 
-impl JSONCloudCreateClusterRequestV4 {
+impl ClusterCreateRequest {
     pub fn new(
         name: String,
         provider: Provider,
@@ -361,7 +298,7 @@ impl Disk {
     }
 }
 
-impl JSONCloudsClustersV4ResponseItem {
+impl Cluster {
     pub fn id(&self) -> String {
         self.id.clone()
     }
@@ -403,5 +340,53 @@ impl JSONCloudsClustersV4ResponseItem {
     }
     pub fn cmek_id(&self) -> Option<String> {
         self.cmek_id.clone()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct BucketsResponse {
+    data: Vec<Bucket>,
+}
+
+impl BucketsResponse {
+    pub fn items(self) -> Vec<Bucket> {
+        self.data
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct Bucket {
+    name: String,
+    #[serde(alias = "type")]
+    bucket_type: String,
+    memory_allocation_in_mb: u64,
+    durability_level: String,
+    replicas: u32,
+    flush: bool,
+    time_to_live_in_seconds: u64,
+}
+
+impl Bucket {
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+    pub fn ram_quota(&self) -> u64 {
+        self.memory_allocation_in_mb
+    }
+    pub fn flush(&self) -> bool {
+        self.flush
+    }
+    pub fn replicas(&self) -> u32 {
+        self.replicas
+    }
+    pub fn bucket_type(&self) -> String {
+        self.bucket_type.clone()
+    }
+    pub fn ttl_seconds(&self) -> u64 {
+        self.time_to_live_in_seconds
+    }
+    pub fn durability_level(&self) -> String {
+        self.durability_level.clone()
     }
 }


### PR DESCRIPTION
The structs in cloud_json.rs all start with CloudJson which is unnecessary, these should be renamed to avoid repetition