### PR TITLE
Improve credentials create

### DIFF
--- a/src/client/cloud_json.rs
+++ b/src/client/cloud_json.rs
@@ -404,13 +404,21 @@ struct Access {
 }
 
 impl CredentialsCreateRequest {
-    pub fn new(name: String, password: String) -> Self {
+    pub fn new(name: String, password: String, read: bool, write: bool) -> Self {
+        let mut privileges = vec![];
+
+        if read {
+            privileges.push("read".to_string())
+        }
+
+        if write {
+            privileges.push("write".to_string())
+        }
+
         Self {
             name,
             password,
-            access: vec![Access {
-                privileges: vec!["write".to_string()],
-            }],
+            access: vec![Access { privileges }],
         }
     }
 }

--- a/src/remote_cluster.rs
+++ b/src/remote_cluster.rs
@@ -152,16 +152,8 @@ impl RemoteCluster {
         self.username.as_str()
     }
 
-    pub fn set_username(&mut self, username: String) {
-        self.username = username;
-    }
-
     pub fn password(&self) -> &str {
         self.password.as_str()
-    }
-
-    pub fn set_password(&mut self, password: String) {
-        self.password = password
     }
 
     pub fn tls_config(&self) -> &Option<RustTlsConfig> {

--- a/src/state.rs
+++ b/src/state.rs
@@ -184,11 +184,6 @@ impl State {
         self.clusters.get(&*active)
     }
 
-    pub fn active_mut_cluster(&mut self) -> Option<&mut RemoteCluster> {
-        let active = self.active.lock().unwrap();
-        self.clusters.get_mut(&*active)
-    }
-
     pub fn tutorial(&self) -> &Tutorial {
         &self.tutorial
     }


### PR DESCRIPTION
This does a few improvements to credentials create:

1) Allows users to specify the privileges of the creds using the --read and --write flags
2) Allows control over whether or not the newly created creds are set to be used by the active cluster
3) If the creds are set for use by the active cluster then we re-build the cluster client. This is needed otherwise when executing data ops against the cluster the new creds would not be used. 