### PR TITLE
Add flag to pass in project to run clusters commands against

### DIFF
--- a/src/cli/clusters.rs
+++ b/src/cli/clusters.rs
@@ -35,6 +35,12 @@ impl Command for Clusters {
                 "the Capella organization to use",
                 None,
             )
+            .named(
+                "project",
+                SyntaxShape::String,
+                "the Capella project to use",
+                None,
+            )
             .category(Category::Custom("couchbase".to_string()))
     }
 
@@ -71,13 +77,17 @@ fn clusters(
         guard.active_capella_org()
     }?;
 
+    let project = call
+        .get_flag(engine_state, stack, "project")?
+        .map_or_else(|| guard.active_project(), Ok)?;
+
     let client = control.client();
     let deadline = Instant::now().add(control.timeout());
 
     let org_id = find_org_id(ctrl_c.clone(), &client, deadline, span)?;
     let project_id = find_project_id(
         ctrl_c.clone(),
-        guard.active_project()?,
+        project,
         &client,
         deadline,
         span,

--- a/src/cli/clusters_create.rs
+++ b/src/cli/clusters_create.rs
@@ -53,6 +53,12 @@ impl Command for ClustersCreate {
                 "the number of nodes in the cluster",
                 None,
             )
+            .named(
+                "project",
+                SyntaxShape::String,
+                "the Capella project to use",
+                None,
+            )
             .category(Category::Custom("couchbase".to_string()))
     }
 
@@ -144,10 +150,14 @@ fn clusters_create(
     let client = control.client();
     let deadline = Instant::now().add(control.timeout());
 
+    let project = call
+        .get_flag(engine_state, stack, "project")?
+        .map_or_else(|| guard.active_project(), Ok)?;
+
     let org_id = find_org_id(ctrl_c.clone(), &client, deadline, span)?;
     let project_id = find_project_id(
         ctrl_c.clone(),
-        guard.active_project()?,
+        project,
         &client,
         deadline,
         span,

--- a/src/cli/clusters_drop.rs
+++ b/src/cli/clusters_drop.rs
@@ -36,6 +36,12 @@ impl Command for ClustersDrop {
                 "the Capella organization to use",
                 None,
             )
+            .named(
+                "project",
+                SyntaxShape::String,
+                "the Capella project to use",
+                None,
+            )
             .category(Category::Custom("couchbase".to_string()))
     }
 
@@ -76,13 +82,17 @@ fn clusters_drop(
         guard.active_capella_org()
     }?;
 
+    let project = call
+        .get_flag(engine_state, stack, "project")?
+        .map_or_else(|| guard.active_project(), Ok)?;
+
     let client = control.client();
     let deadline = Instant::now().add(control.timeout());
 
     let org_id = find_org_id(ctrl_c.clone(), &client, deadline, span)?;
     let project_id = find_project_id(
         ctrl_c.clone(),
-        guard.active_project()?,
+        project,
         &client,
         deadline,
         span,

--- a/src/cli/clusters_get.rs
+++ b/src/cli/clusters_get.rs
@@ -36,6 +36,12 @@ impl Command for ClustersGet {
                 "the Capella organization to use",
                 None,
             )
+            .named(
+                "project",
+                SyntaxShape::String,
+                "the Capella project to use",
+                None,
+            )
             .category(Category::Custom("couchbase".to_string()))
     }
 
@@ -75,13 +81,18 @@ fn clusters_get(
     } else {
         guard.active_capella_org()
     }?;
+
+    let project = call
+        .get_flag(engine_state, stack, "project")?
+        .map_or_else(|| guard.active_project(), Ok)?;
+
     let client = control.client();
     let deadline = Instant::now().add(control.timeout());
 
     let org_id = find_org_id(ctrl_c.clone(), &client, deadline, span)?;
     let project_id = find_project_id(
         ctrl_c.clone(),
-        guard.active_project()?,
+        project,
         &client,
         deadline,
         span,


### PR DESCRIPTION
At the moment all the clusters commands run against the active project. I'd be nice to have a flag to override this behaviour for easier management of clusters across various projects. 