### PR TITLE
enable is_empty and is_not_empty nu_command

### DIFF
--- a/src/default_context.rs
+++ b/src/default_context.rs
@@ -104,6 +104,8 @@ pub fn create_default_context() -> EngineState {
             GroupBy,
             Headers,
             Insert,
+            IsEmpty,
+            IsNotEmpty,
             Items,
             Join,
             SplitBy,


### PR DESCRIPTION
For issue  #412, allow new commands to check is dataframes are empty or not.
