### PR TITLE
Set num_replicas to 0 for buckets created on single node clusters

### DIFF
--- a/src/cli/buckets_get.rs
+++ b/src/cli/buckets_get.rs
@@ -239,7 +239,7 @@ pub(crate) fn bucket_to_nu_value(
     collected.add_string("cluster", cluster_name, span);
     collected.add_string("name", bucket.name(), span);
     collected.add_string("type", bucket.bucket_type().to_string(), span);
-    collected.add_i64("replicas", bucket.num_replicas() as i64, span);
+    collected.add_i64("replicas", bucket.num_replicas().unwrap() as i64, span);
     collected.add_string(
         "min_durability_level",
         bucket.minimum_durability_level().to_string(),

--- a/src/client/cloud_json.rs
+++ b/src/client/cloud_json.rs
@@ -98,6 +98,17 @@ pub(crate) struct Cluster {
     cmek_id: Option<String>,
 }
 
+impl Cluster {
+    pub fn total_nodes(&self) -> i32 {
+        let mut total = 0;
+
+        for sg in &self.service_groups {
+            total = sg.num_of_nodes.unwrap() + total;
+        }
+        total
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct CloudProvider {
     #[serde(rename(serialize = "type"))]


### PR DESCRIPTION
Addresses: https://github.com/couchbaselabs/couchbase-shell/issues/440

The `unwrap()`s in:

- buckets_get is fine, since num_replicas will always be set when fetching the settings, it's only going to be None when creating a bucket
- cloud_json.rs/total_nodes is fine since we only call it on fetched json clusters, which will always have this set