### PR TITLE
Read plugin file when running commands or scripts

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ use log::{debug, warn};
 use log::{error, info};
 use serde::Deserialize;
 
-use nu_cli::{add_plugin_file, gather_parent_env_vars, read_plugin_file, EvaluateCommandsOpts};
+use nu_cli::{gather_parent_env_vars, read_plugin_file, EvaluateCommandsOpts};
 use nu_cmd_base::util::get_init_cwd;
 use nu_protocol::engine::{EngineState, Stack, StateWorkingSet};
 use nu_protocol::{
@@ -148,7 +148,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     if let Some(c) = opt.command {
         context.generate_nu_constant();
-        add_plugin_file(&mut context, None, CBSHELL_FOLDER);
+        read_plugin_file(&mut context, None, CBSHELL_FOLDER);
         let opts = EvaluateCommandsOpts {
             table_mode: None,
             error_style: None,
@@ -161,7 +161,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     if let Some(filepath) = opt.script {
         context.generate_nu_constant();
-        add_plugin_file(&mut context, None, CBSHELL_FOLDER);
+        read_plugin_file(&mut context, None, CBSHELL_FOLDER);
         nu_cli::evaluate_file(filepath, &args_to_script, &mut context, &mut stack, input)
             .expect("Failed to run script");
 


### PR DESCRIPTION
Addresses: https://github.com/couchbaselabs/couchbase-shell/issues/545

Plugins are now correctly loaded when running commands and scripts with CBShell.  When running in the shell we see the following: 
```
👤 Administrator 🏠 remote in ☁️ travel-sample._default._default
> plugin list
╭───┬───────┬─────────┬────────────┬─────┬────────────────────────────────────────────────┬───────┬───────────────╮
│ # │ name  │ version │ is_running │ pid │                    filename                    │ shell │   commands    │
├───┼───────┼─────────┼────────────┼─────┼────────────────────────────────────────────────┼───────┼───────────────┤
│ 0 │ gstat │ 0.95.0  │ false      │     │ /Users/jackwestwood/.cargo/bin/nu_plugin_gstat │       │ ╭───┬───────╮ │
│   │       │         │            │     │                                                │       │ │ 0 │ gstat │ │
│   │       │         │            │     │                                                │       │ ╰───┴───────╯ │
│ 1 │ inc   │ 0.95.0  │ false      │     │ /Users/jackwestwood/.cargo/bin/nu_plugin_inc   │       │ ╭───┬─────╮   │
│   │       │         │            │     │                                                │       │ │ 0 │ inc │   │
│   │       │         │            │     │                                                │       │ ╰───┴─────╯   │
╰───┴───────┴─────────┴────────────┴─────┴────────────────────────────────────────────────┴───────┴───────────────╯
```

When passing in a command: 
```
➜  couchbase-shell git:(load_cmd_script_plugins) ✗ cargo run -- -c "plugin list"
    Finished dev [unoptimized + debuginfo] target(s) in 0.52s
     Running `target/debug/cbsh -c 'plugin list'`
[WARN] 2024-10-18 12:40:09.804 Using PLAIN authentication for cluster local, credentials will sent in plaintext - configure tls to disable this warning
╭───┬───────┬─────────┬────────────┬─────┬────────────────────────────────────────────────┬───────┬───────────────╮
│ # │ name  │ version │ is_running │ pid │                    filename                    │ shell │   commands    │
├───┼───────┼─────────┼────────────┼─────┼────────────────────────────────────────────────┼───────┼───────────────┤
│ 0 │ gstat │ 0.95.0  │ false      │     │ /Users/jackwestwood/.cargo/bin/nu_plugin_gstat │       │ [list 1 item] │
│ 1 │ inc   │ 0.95.0  │ false      │     │ /Users/jackwestwood/.cargo/bin/nu_plugin_inc   │       │ [list 1 item] │
╰───┴───────┴─────────┴────────────┴─────┴────────────────────────────────────────────────┴───────┴───────────────
```

When using a script: 
```
➜  couchbase-shell git:(load_cmd_script_plugins) ✗ cat script.nu
plugin list
➜  couchbase-shell git:(load_cmd_script_plugins) ✗ cargo run -- --script script.nu
    Finished dev [unoptimized + debuginfo] target(s) in 0.60s
     Running `target/debug/cbsh --script script.nu`
[WARN] 2024-10-18 12:40:53.305 Using PLAIN authentication for cluster local, credentials will sent in plaintext - configure tls to disable this warning
╭───┬───────┬─────────┬────────────┬─────┬────────────────────────────────────────────────┬───────┬───────────────╮
│ # │ name  │ version │ is_running │ pid │                    filename                    │ shell │   commands    │
├───┼───────┼─────────┼────────────┼─────┼────────────────────────────────────────────────┼───────┼───────────────┤
│ 0 │ gstat │ 0.95.0  │ false      │     │ /Users/jackwestwood/.cargo/bin/nu_plugin_gstat │       │ ╭───┬───────╮ │
│   │       │         │            │     │                                                │       │ │ 0 │ gstat │ │
│   │       │         │            │     │                                                │       │ ╰───┴───────╯ │
│ 1 │ inc   │ 0.95.0  │ false      │     │ /Users/jackwestwood/.cargo/bin/nu_plugin_inc   │       │ ╭───┬─────╮   │
│   │       │         │            │     │                                                │       │ │ 0 │ inc │   │
│   │       │         │            │     │                                                │       │ ╰───┴─────╯   │
╰───┴───────┴─────────┴────────────┴─────┴────────────────────────────────────────────────┴───────┴───────────────╯
```