### PR TITLE
Add plugin feature to nu-command import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,6 +3169,7 @@ dependencies = [
  "log",
  "nu-engine",
  "nu-path",
+ "nu-plugin-engine",
  "nu-protocol",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ nu-cmd-base = { version = "0.95.0" }
 nu-cmd-extra = { version = "0.95.0" }
 nu-cmd-lang = { version = "0.95.0" }
 nu-cmd-plugin = { version = "0.95.0" }
-nu-command = { version = "0.95.0" }
+nu-command = { version = "0.95.0", features = ["plugin"] }
 nu-explore = { version = "0.95.0" }
 nu-parser = { version = "0.95.0" }
 nu-path = { version = "0.95.0" }


### PR DESCRIPTION
Addresses: https://github.com/couchbaselabs/couchbase-shell/issues/547

Plugin use now results in the plugin being available in the current session: 

```
> plugin list
╭────────────╮
│ empty list │
╰────────────╯
👤 Administrator 🏠 remote in ☁️ travel-sample._default._default
> plugin use gstat
👤 Administrator 🏠 remote in ☁️ travel-sample._default._default
> plugin list
╭───┬───────┬─────────┬────────────┬─────┬────────────────────────────────────────────────┬───────┬───────────────╮
│ # │ name  │ version │ is_running │ pid │                    filename                    │ shell │   commands    │
├───┼───────┼─────────┼────────────┼─────┼────────────────────────────────────────────────┼───────┼───────────────┤
│ 0 │ gstat │ 0.95.0  │ false      │     │ /Users/jackwestwood/.cargo/bin/nu_plugin_gstat │       │ ╭───┬───────╮ │
│   │       │         │            │     │                                                │       │ │ 0 │ gstat │ │
│   │       │         │            │     │                                                │       │ ╰───┴───────╯ │
╰───┴───────┴─────────┴────────────┴─────┴────────────────────────────────────────────────┴───────┴───────────────╯
```

A bit of a strange one. The `plugin use` command has an empty body, the function of adding a plugin signature to the working set is done by nushell calling `parse_builtin_commands`. However the case for `plugin use` is behind a cargo feature, so unless the plugin enabled for nu-command  plugin use does nothing. The other plugin commands have their functionality in the command body which is why they all worked as expected before this fix.