### PR TITLE
Support SELECT field name with spaces

### DIFF
--- a/query_autocomplete/fields_tests.nu
+++ b/query_autocomplete/fields_tests.nu
@@ -23,44 +23,44 @@ const SELECT_tests = [
     {
         # Suggest list of fields after SELECT
         input: "FROM route SELECT "
-        expected: [* airline airlineid destinationairport distance equipment id schedule sourceairport stops type]
+        expected: [* "`airline`" "`airlineid`" "`destinationairport`" "`distance`" "`equipment`" "`id`" "`schedule`" "`sourceairport`" "`stops`" "`type`"]
     }
     {
         # Suggest WHERE and all other fields after *
         input: "FROM route SELECT * "
-        expected: [WHERE airline airlineid destinationairport distance equipment id schedule sourceairport stops type]
+        expected: [WHERE "`airline`" "`airlineid`" "`destinationairport`" "`distance`" "`equipment`" "`id`" "`schedule`" "`sourceairport`" "`stops`" "`type`"]
     }
     {
         # Suggest list of fields and WHERE after SELECT meta().id
         input: "FROM route SELECT meta().id "
-        expected: [WHERE * airline airlineid destinationairport distance equipment id schedule sourceairport stops type]
+        expected: [WHERE * "`airline`" "`airlineid`" "`destinationairport`" "`distance`" "`equipment`" "`id`" "`schedule`" "`sourceairport`" "`stops`" "`type`"]
     }
     {
         # Don't suggest used fields
-        input: "FROM route SELECT airline distance schedule type "
-        expected: [WHERE * airlineid destinationairport equipment id sourceairport stops]
+        input: "FROM route SELECT `airline` `distance` `schedule` `type` "
+        expected: [WHERE * "`airlineid`" "`destinationairport`" "`equipment`" "`id`" "`sourceairport`" "`stops`"]
     }
     {
         # Correctly detect used fields when meta().id present
-        input: "FROM route SELECT airline meta().id distance schedule type "
-        expected: [WHERE * airlineid destinationairport equipment id sourceairport stops]
+        input: "FROM route SELECT `airline` meta().id `distance` `schedule` `type` "
+        expected: [WHERE * "`airlineid`" "`destinationairport`" "`equipment`" "`id`" "`sourceairport`" "`stops`"]
     }
     {
         # Handle fields with spaces in the names
-        input: "FROM route SELECT airline 'space field' distance schedule type "
-        expected: [WHERE * airlineid destinationairport equipment id sourceairport stops]
+        input: "FROM route SELECT `airline` `space field` `distance` `schedule` `type` "
+        expected: [WHERE * "`airlineid`" "`destinationairport`" "`equipment`" "`id`" "`sourceairport`" "`stops`"]
     }
 ]
 
 const WHERE_tests = [
     {
         # Suggest all fields after WHERE
-        input: "FROM route SELECT airline distance schedule type WHERE "
-        expected: [airline airlineid destinationairport distance equipment id schedule sourceairport stops type]
+        input: "FROM route SELECT `airline` `distance` `schedule` `type` WHERE "
+        expected: ["`airline`" "`airlineid`" "`destinationairport`" "`distance`" "`equipment`" "`id`" "`schedule`" "`sourceairport`" "`stops`" "`type`"]
     }
     {
         # Suggest operators after field
-        input: "FROM route SELECT * WHERE airline "
+        input: "FROM route SELECT * WHERE `airline` "
         expected: $cli_operators
     }
     {
@@ -75,12 +75,12 @@ const WHERE_tests = [
     }
     {
          # Suggest operator after WHERE field with underscore
-         input: "FROM route SELECT * WHERE some_field "
+         input: "FROM route SELECT * WHERE `some_field` "
          expected: $cli_operators
     }
     {
         # Suggest nothing after operator
-        input: "FROM route SELECT airline distance schedule type WHERE airline == "
+        input: "FROM route SELECT `airline` `distance` `schedule` `type` WHERE `airline` == "
         expected: null
     }
 ]

--- a/query_autocomplete/format_query.nu
+++ b/query_autocomplete/format_query.nu
@@ -47,11 +47,19 @@ def format_after_where [fields: list] {
     # return a table containing the index of the value in $after_where and the corresponding value
     let $condition_values = ($after_where | enumerate | each {|it| if ($it.item in $operators) {($after_where | get ($it.index + 1)) | [[index value]; [($it.index + 1) $in]]}}) | flatten
 
+    # Get all of the fields in the condition clauses, the values are determined as being the items that proceed operators
+    # return a table containing the index of the field names in $after_where and the corresponding field name wrapped in backticks
+    let $condition_fields = ($after_where | enumerate | each {|it| if ($it.item in $operators) {($after_where | get ($it.index - 1)) | [[index value]; [($it.index - 1) (["`" $in "`"] | str join)]]}}) | flatten
+
     mut $formatted_after_where = $after_where
     for item in $condition_values {
         # Iterate over all condition values and wrap any non-numbers (strings) in quote marks
         let $formatted_value = (if (is_number $item.value) {$item.value} else {['"' $item.value '"'] | str join})
         $formatted_after_where = ($formatted_after_where | update $item.index $formatted_value)
+    }
+
+    for $item in $condition_fields {
+        $formatted_after_where = ($formatted_after_where | update $item.index $item.value)
     }
 
     $formatted_after_where

--- a/query_autocomplete/format_query_tests.nu
+++ b/query_autocomplete/format_query_tests.nu
@@ -33,28 +33,28 @@ const WHERE_tests = [
     {
         # Basic query with WHERE clause
         input: [col SELECT * WHERE field == value]
-        expected: 'SELECT * FROM col WHERE field = "value"'
+        expected: 'SELECT * FROM col WHERE `field` = "value"'
     }
     {
         # Multiple fields
         input: [col SELECT field1 field2 WHERE field3 == value]
-        expected: 'SELECT `field1`, `field2` FROM col WHERE field3 = "value"'
+        expected: 'SELECT `field1`, `field2` FROM col WHERE `field3` = "value"'
     }
     {
         # Condition value with spaces
         input: [col SELECT * WHERE field == 'some value']
-        expected: 'SELECT * FROM col WHERE field = "some value"'
+        expected: 'SELECT * FROM col WHERE `field` = "some value"'
     }
     {
         # Don't wrap int or float condition values in quote marks
         # Note that we quote the numbers in the list because they will be passed to format_query as strings
         input: [col SELECT field WHERE field1 == '10' AND field2 == '10.5']
-        expected: 'SELECT `field` FROM col WHERE field1 = 10 AND field2 = 10.5'
+        expected: 'SELECT `field` FROM col WHERE `field1` = 10 AND `field2` = 10.5'
     }
     {
         # LIKE with wildcard
         input: [col SELECT * WHERE field LIKE '%alue']
-        expected: 'SELECT * FROM col WHERE field LIKE "%alue"'
+        expected: 'SELECT * FROM col WHERE `field` LIKE "%alue"'
     }
 ]
 


### PR DESCRIPTION
Currently if the named fields to be SELECTed contain spaces then the query autocomplete does not detect that they have been used and suggests them again, e.g: 

```
👤 Administrator 🏠 local in 🗄 travel-sample.inventory._default
| FROM testing SELECT some field
*                   WHERE               another field       some field
```

This PR fixes this by wrapping all SELECT fields in backticks and using these to split the partial query, resulting in: 

```
👤 Administrator 🏠 local in 🗄 travel-sample.inventory._default
| FROM testing SELECT `some field`
*                   WHERE               `another field`
```