### PR TITLE
Satisfies keyword

### DIFF
--- a/query_autocomplete/fields.nu
+++ b/query_autocomplete/fields.nu
@@ -41,8 +41,8 @@ export def main [context: string] {
             IN => {
                 let $collection = ($context | split words | $in.1)
                 let $array_fields = (collection_fields $collection| filter {|it| $it.type == array} | get fields)
-                # There is a with the nushell completions where nothing is displayed if all the completions start the same
-                # So we append an empty space to the list of array fields to work around this
+                # There is an issue with the nushell completions where nothing is displayed if all the completions start the same
+                # So we append an empty space to the list of array fields to work around this for now
                 return { options: {sort: false}, completions: ($array_fields | append " ")}
             }
             SATISFIES => {
@@ -65,7 +65,7 @@ export def main [context: string] {
                        return [$alias]
                 }
 
-                # There is a with the nushell completions where nothing is displayed if all the completions start the same
+                # There is an issue with the nushell completions where nothing is displayed if all the completions start the same
                 # So we append an empty space to the list of array fields to work around this
                 let $formatted_array_fields = ($array_object_fields | columns | each {|it| $array_object_fields | get $it | columns | if ("properties" in $in) {$array_object_fields | get $it | get properties | columns | each {|prop| [$alias . $it . '`' $prop '`'] | str join }} else { [$alias . '`' $it '`'] | str join} } | flatten | append " ")
                 return { options: {sort: false}, completions: $formatted_array_fields}
@@ -120,14 +120,7 @@ export def main [context: string] {
         }
         ANY => [IN]
         EVERY => [IN]
-        IN => {
-            # Cases
-            # either
-            # IN y => [SATISFIES]
-            # IN x <operator> => Nothing
-            # IN x <operator> y
-            [SATISFIES]
-        }
+        IN => [SATISFIES]
         SATISFIES => {
             # If an operator is last argument suggest nothing
             if ($last in $cli_operators) {

--- a/query_autocomplete/format_query_tests.nu
+++ b/query_autocomplete/format_query_tests.nu
@@ -61,10 +61,30 @@ const AND_tests = [
     }
 ]
 
+const SATISFIES_tests = [
+    {
+        # Don't wrap the element.`field` pair in more backticks
+        input: [col SELECT field WHERE ANY element IN array SATISFIES "element.`field`" == value END]
+        expected: 'SELECT `field` FROM col WHERE ANY element IN array SATISFIES element.`field` = "value" END'
+    }
+    {
+        # Same as above with int value
+        input: [col SELECT field WHERE ANY element IN array SATISFIES "element.`field`" == '11' END]
+        expected: 'SELECT `field` FROM col WHERE ANY element IN array SATISFIES element.`field` = 11 END'
+    }
+    {
+        # It is fine to wrap the element when it is not referencing a nested field
+        input: [col SELECT field WHERE ANY element IN array SATISFIES element == value END]
+        expected: 'SELECT `field` FROM col WHERE ANY element IN array SATISFIES `element` = "value" END'
+    }
+]
+
 export def main [] {
     let tests = [
         ...$SELECT_tests
         ...$WHERE_tests
+        ...$AND_tests
+        ...$SATISFIES_tests
     ]
 
     for test in $tests {

--- a/query_autocomplete/utils.nu
+++ b/query_autocomplete/utils.nu
@@ -1,8 +1,8 @@
 export def assert [expected, result] {
        if (not ($expected == $result)) {
        print (ansi red_bold) failed (ansi reset)
-       print "EXPECTED: " $expected
-       print "RESULT: " $result
+       print "EXPECTED: " ($expected | flatten)
+       print "RESULT: " ($result | flatten)
    } else {
        print (ansi green_bold) passed (ansi reset)
    }


### PR DESCRIPTION
This PR adds support for the SATISFIES keyword to the query autocomplete feature. This also means that ANY, EVERY, IN and END were also added so that valid SATISFIES clauses can be constructed.