### PR TITLE
Fix query formatting when LIMIT used without WHERE

### DIFF
--- a/query_autocomplete/format_query_tests.nu
+++ b/query_autocomplete/format_query_tests.nu
@@ -79,12 +79,24 @@ const SATISFIES_tests = [
     }
 ]
 
+const LIMIT_tests = [
+    {
+        input: [col SELECT * LIMIT 10]
+        expected: 'SELECT * FROM col LIMIT 10'
+    }
+    {
+        input: [col SELECT * WHERE field == value LIMIT 10]
+        expected: 'SELECT * FROM col WHERE `field` = "value" LIMIT 10'
+    }
+]
+
 export def main [] {
     let tests = [
         ...$SELECT_tests
         ...$WHERE_tests
         ...$AND_tests
         ...$SATISFIES_tests
+        ...$LIMIT_tests
     ]
 
     for test in $tests {


### PR DESCRIPTION
When formatting the input to the query autocomplete command we use the location of the WHERE  keyword to determine the end of the fields to be returned from the documents and these fields are then wrapped in backticks. 

When the query does not have a WHERE, and has a LIMIT this makes the command think that the LIMIT and following number are also part of the return fields and the query is incorrectly formatted.

This PR updates the format query logic to handle the case where we have a LIMIT without a WHERE and adds a test for this case.