### PR TITLE
Upgrade default log level to error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -299,7 +299,7 @@ fn validate_hostnames(hostnames: Vec<String>) -> (RemoteClusterType, Vec<String>
 
 fn create_logger_builder(logger_prefix: Option<String>) {
     let mut logger_builder = env_logger::Builder::from_env(
-        Env::default().filter_or("CBSH_LOG", "info,isahc=error,surf=error,nu=warn"),
+        Env::default().filter_or("CBSH_LOG", "info,isahc=error,surf=error,nu=error"),
     );
 
     logger_builder.format(move |buf, record| {


### PR DESCRIPTION
Currently there are warning messages related to the custom prompt: 

```
➜  couchbase-shell git:(main) ✗ cargo run
   Compiling couchbase-shell v1.1.0 (/Users/jackwestwood/cbshell/couchbase-shell)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.25s
     Running `target/debug/cbsh`
[WARN] 2025-04-10 14:57:51.033 Using PLAIN authentication for cluster local, credentials will sent in plaintext - configure tls to disable this warning
[INFO] 2025-04-10 14:57:51.255 Thanks for trying CBSH!
[WARN] 2025-04-10 14:57:51.325 /Users/jackwestwood/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nu-cli-0.101.0/src/prompt_update.rs:101:54 Some("👤 \u{1b}[1;34mAdministrator\u{1b}[0m 🏠 \u{1b}[1;33mlocal\u{1b}[0m in 🗄 \u{1b}[1;37mtravel-sample.inventory._default\u{1b}[0m\n")
[WARN] 2025-04-10 14:57:51.325 /Users/jackwestwood/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nu-cli-0.101.0/src/prompt_update.rs:101:54 Some("\u{1b}[0m")
👤 Administrator 🏠 local in 🗄 travel-sample.inventory._default
>
```

These come from a message printed when the log level is warn in `get_prompt_string`:

```
  // Let's keep this for debugging purposes with nu --log-level warn
  warn!("{}:{}:{} {:?}", file!(), line!(), column!(), ansi_output);
```